### PR TITLE
Add uuid package to Bazel build deps

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -112,9 +112,11 @@ ts_project(
     declaration = True,
     deps = [
         "@npm//@grpc/grpc-js",
-        "@npm//grakn-protocol",
         "@npm//@types/node",
+        "@npm//@types/uuid",
+        "@npm//grakn-protocol",
         "@npm//typescript",
+        "@npm//uuid",
     ],
 )
 


### PR DESCRIPTION
## What is the goal of this PR?

We added `uuid` and its types package to the dependencies of Bazel build, allowing the project to build
