### PR TITLE
Replace methods with properties where appropriate

### DIFF
--- a/TypeDB.ts
+++ b/TypeDB.ts
@@ -36,5 +36,4 @@ export namespace TypeDB {
         if (typeof addresses === 'string') addresses = [addresses];
         return new ClusterClient(addresses, credential).open();
     }
-
 }

--- a/api/answer/ConceptMap.ts
+++ b/api/answer/ConceptMap.ts
@@ -19,23 +19,20 @@
  * under the License.
  */
 
-
 import { Concept } from "../concept/Concept";
 
 export interface ConceptMap {
 
-    map(): Map<string, Concept>;
+    readonly map: Map<string, Concept>;
 
     concepts(): IterableIterator<Concept>
 
-    get(variable: string): Concept
+    get(variable: string): Concept;
 
-    explainables(): ConceptMap.Explainables;
-
+    readonly explainables: ConceptMap.Explainables;
 }
 
 export namespace ConceptMap {
-
 
     export interface Explainables {
 
@@ -45,20 +42,17 @@ export namespace ConceptMap {
 
         ownership(owner: string, attribute: string): Explainable;
 
-        relations(): Map<string, Explainable>;
+        readonly relations: Map<string, Explainable>;
 
-        attributes(): Map<string, Explainable>;
+        readonly attributes: Map<string, Explainable>;
 
-        ownerships(): Map<[string, string], Explainable>;
-
+        readonly ownerships: Map<[string, string], Explainable>;
     }
 
     export interface Explainable {
 
-        conjunction(): string;
+        readonly conjunction: string;
 
-        id(): number;
-
+        readonly id: number;
     }
-
 }

--- a/api/answer/ConceptMapGroup.ts
+++ b/api/answer/ConceptMapGroup.ts
@@ -24,8 +24,7 @@ import { ConceptMap } from "./ConceptMap";
 
 export interface ConceptMapGroup {
 
-    owner(): Concept;
+    readonly owner: Concept;
 
-    conceptMaps(): ConceptMap[];
-
+    readonly conceptMaps: ConceptMap[];
 }

--- a/api/answer/Numeric.ts
+++ b/api/answer/Numeric.ts
@@ -26,5 +26,4 @@ export interface Numeric {
     isNaN(): boolean;
 
     asNumber(): number;
-
 }

--- a/api/answer/NumericGroup.ts
+++ b/api/answer/NumericGroup.ts
@@ -24,8 +24,7 @@ import { Numeric } from "./Numeric";
 
 export interface NumericGroup {
 
-    owner(): Concept;
+    readonly owner: Concept;
 
-    numeric(): Numeric;
-
+    readonly numeric: Numeric;
 }

--- a/api/concept/Concept.ts
+++ b/api/concept/Concept.ts
@@ -79,7 +79,6 @@ export interface Concept {
     asRelation(): Relation;
 
     equals(concept: Concept): boolean;
-
 }
 
 export namespace Concept {

--- a/api/concept/ConceptManager.ts
+++ b/api/concept/ConceptManager.ts
@@ -50,5 +50,4 @@ export interface ConceptManager {
     getAttributeType(label: string): Promise<AttributeType>;
 
     putAttributeType(label: string, valueType: AttributeType.ValueType): Promise<AttributeType>;
-
 }

--- a/api/concept/thing/Attribute.ts
+++ b/api/concept/thing/Attribute.ts
@@ -35,9 +35,9 @@ export interface Attribute extends Thing {
 
     asRemote(transaction: TypeDBTransaction): Attribute.Remote;
 
-    getType(): AttributeType;
+    readonly type: AttributeType;
 
-    getValue(): boolean | string | number | Date;
+    readonly value: boolean | string | number | Date;
 
     isBoolean(): boolean;
 
@@ -66,7 +66,7 @@ export namespace Attribute {
 
         asRemote(transaction: TypeDBTransaction): Attribute.Remote;
 
-        getType(): AttributeType;
+        readonly type: AttributeType;
 
         getOwners(ownerType?: ThingType): Stream<Thing>;
 
@@ -105,9 +105,9 @@ export namespace Attribute {
 
         asRemote(transaction: TypeDBTransaction): Attribute.Boolean.Remote;
 
-        getType(): AttributeType.Boolean;
+        readonly type: AttributeType.Boolean;
 
-        getValue(): boolean;
+        readonly value: boolean;
     }
 
     export namespace Boolean {
@@ -116,9 +116,9 @@ export namespace Attribute {
 
             asRemote(transaction: TypeDBTransaction): Attribute.Boolean.Remote;
 
-            getType(): AttributeType.Boolean;
+            readonly type: AttributeType.Boolean;
 
-            getValue(): boolean;
+            readonly value: boolean;
 
             asType(): Type.Remote;
 
@@ -156,9 +156,9 @@ export namespace Attribute {
 
         asRemote(transaction: TypeDBTransaction): Attribute.Long.Remote;
 
-        getType(): AttributeType.Long;
+        readonly type: AttributeType.Long;
 
-        getValue(): number;
+        readonly value: number;
     }
 
     export namespace Long {
@@ -167,9 +167,9 @@ export namespace Attribute {
 
             asRemote(transaction: TypeDBTransaction): Attribute.Long.Remote;
 
-            getType(): AttributeType.Long;
+            readonly type: AttributeType.Long;
 
-            getValue(): number;
+            readonly value: number;
 
             asType(): Type.Remote;
 
@@ -207,9 +207,9 @@ export namespace Attribute {
 
         asRemote(transaction: TypeDBTransaction): Attribute.Double.Remote;
 
-        getType(): AttributeType.Double;
+        readonly type: AttributeType.Double;
 
-        getValue(): number;
+        readonly value: number;
     }
 
     export namespace Double {
@@ -218,9 +218,9 @@ export namespace Attribute {
 
             asRemote(transaction: TypeDBTransaction): Attribute.Double.Remote;
 
-            getType(): AttributeType.Double;
+            readonly type: AttributeType.Double;
 
-            getValue(): number;
+            readonly value: number;
 
             asType(): Type.Remote;
 
@@ -258,9 +258,9 @@ export namespace Attribute {
 
         asRemote(transaction: TypeDBTransaction): Attribute.String.Remote;
 
-        getType(): AttributeType.String;
+        readonly type: AttributeType.String;
 
-        getValue(): string;
+        readonly value: string;
     }
 
     export namespace String {
@@ -269,9 +269,9 @@ export namespace Attribute {
 
             asRemote(transaction: TypeDBTransaction): Attribute.String.Remote;
 
-            getType(): AttributeType.String;
+            readonly type: AttributeType.String;
 
-            getValue(): string;
+            readonly value: string;
 
             asType(): Type.Remote;
 
@@ -309,9 +309,9 @@ export namespace Attribute {
 
         asRemote(transaction: TypeDBTransaction): Attribute.DateTime.Remote;
 
-        getType(): AttributeType.DateTime;
+        readonly type: AttributeType.DateTime;
 
-        getValue(): Date;
+        readonly value: Date;
     }
 
     export namespace DateTime {
@@ -320,9 +320,9 @@ export namespace Attribute {
 
             asRemote(transaction: TypeDBTransaction): Attribute.DateTime.Remote;
 
-            getType(): AttributeType.DateTime;
+            readonly type: AttributeType.DateTime;
 
-            getValue(): Date;
+            readonly value: Date;
 
             asType(): Type.Remote;
 

--- a/api/concept/thing/Entity.ts
+++ b/api/concept/thing/Entity.ts
@@ -34,8 +34,7 @@ export interface Entity extends Thing {
 
     asRemote(transaction: TypeDBTransaction): Entity.Remote;
 
-    getType(): EntityType;
-
+    readonly type: EntityType;
 }
 
 export namespace Entity {
@@ -44,7 +43,7 @@ export namespace Entity {
 
         asRemote(transaction: TypeDBTransaction): Entity.Remote;
 
-        getType(): EntityType;
+        readonly type: EntityType;
 
         asType(): Type.Remote;
 

--- a/api/concept/thing/Relation.ts
+++ b/api/concept/thing/Relation.ts
@@ -35,7 +35,7 @@ export interface Relation extends Thing {
 
     asRemote(transaction: TypeDBTransaction): Relation.Remote;
 
-    getType(): RelationType;
+    readonly type: RelationType;
 }
 
 export namespace Relation {
@@ -44,7 +44,7 @@ export namespace Relation {
 
         asRemote(transaction: TypeDBTransaction): Relation.Remote;
 
-        getType(): RelationType;
+        readonly type: RelationType;
 
         asType(): Type.Remote;
 

--- a/api/concept/thing/Thing.ts
+++ b/api/concept/thing/Thing.ts
@@ -37,11 +37,11 @@ export interface Thing extends Concept {
 
     asRemote(transaction: TypeDBTransaction): Thing.Remote;
 
-    getIID(): string;
+    readonly iid: string;
 
-    getType(): ThingType;
+    readonly type: ThingType;
 
-    isInferred(): boolean;
+    readonly inferred: boolean;
 }
 
 export namespace Thing {
@@ -98,6 +98,6 @@ export namespace Thing {
     }
 
     export function proto(thing: Thing) {
-        return RequestBuilder.Thing.protoThing(thing.getIID());
+        return RequestBuilder.Thing.protoThing(thing.iid);
     }
 }

--- a/api/concept/type/AttributeType.ts
+++ b/api/concept/type/AttributeType.ts
@@ -34,7 +34,7 @@ import { Type } from "./Type";
 
 export interface AttributeType extends ThingType {
 
-    getValueType(): AttributeType.ValueType;
+    readonly valueType: AttributeType.ValueType;
 
     isBoolean(): boolean;
 
@@ -57,7 +57,6 @@ export interface AttributeType extends ThingType {
     asDateTime(): AttributeType.DateTime;
 
     asRemote(transaction: TypeDBTransaction): AttributeType.Remote;
-
 }
 
 /* eslint @typescript-eslint/ban-types: "off" */

--- a/api/concept/type/RelationType.ts
+++ b/api/concept/type/RelationType.ts
@@ -34,7 +34,6 @@ import { Type } from "./Type";
 export interface RelationType extends ThingType {
 
     asRemote(transaction: TypeDBTransaction): RelationType.Remote;
-
 }
 
 export namespace RelationType {

--- a/api/concept/type/RoleType.ts
+++ b/api/concept/type/RoleType.ts
@@ -77,6 +77,6 @@ export namespace RoleType {
     }
 
     export function proto(roleType: RoleType) {
-        return RequestBuilder.Type.RoleType.protoRoleType(roleType.getLabel(), Type.encoding(roleType));
+        return RequestBuilder.Type.RoleType.protoRoleType(roleType.label, Type.encoding(roleType));
     }
 }

--- a/api/concept/type/ThingType.ts
+++ b/api/concept/type/ThingType.ts
@@ -104,6 +104,6 @@ export namespace ThingType {
     }
 
     export function proto(thingType: ThingType) {
-        return RequestBuilder.Type.ThingType.protoThingType(thingType.getLabel(), Type.encoding(thingType));
+        return RequestBuilder.Type.ThingType.protoThingType(thingType.label, Type.encoding(thingType));
     }
 }

--- a/api/concept/type/Type.ts
+++ b/api/concept/type/Type.ts
@@ -40,9 +40,9 @@ import BAD_ENCODING = ErrorMessage.Concept.BAD_ENCODING;
 
 export interface Type extends Concept {
 
-    getLabel(): Label;
+    readonly label: Label;
 
-    isRoot(): boolean;
+    readonly root: boolean;
 
     asRemote(transaction: TypeDBTransaction): Type.Remote;
 }

--- a/api/connection/TypeDBClient.ts
+++ b/api/connection/TypeDBClient.ts
@@ -19,7 +19,6 @@
  * under the License.
  */
 
-
 import { DatabaseManager } from "./database/DatabaseManager";
 import { TypeDBOptions } from "./TypeDBOptions";
 import { SessionType, TypeDBSession } from "./TypeDBSession";
@@ -29,7 +28,7 @@ export interface TypeDBClient {
 
     isOpen(): boolean;
 
-    databases(): DatabaseManager;
+    readonly databases: DatabaseManager;
 
     session(database: string, type: SessionType, options?: TypeDBOptions): Promise<TypeDBSession>;
 
@@ -38,16 +37,14 @@ export interface TypeDBClient {
     asCluster(): TypeDBClient.Cluster;
 
     close(): void;
-
 }
 
 export namespace TypeDBClient {
 
     export interface Cluster extends TypeDBClient {
 
-        users(): UserManager;
+        readonly users: UserManager;
 
-        databases(): DatabaseManager.Cluster;
-
+        readonly databases: DatabaseManager.Cluster;
     }
 }

--- a/api/connection/TypeDBCredential.ts
+++ b/api/connection/TypeDBCredential.ts
@@ -26,9 +26,9 @@ import CLUSTER_INVALID_ROOT_CA_PATH = ErrorMessage.Client.CLUSTER_INVALID_ROOT_C
 
 export class TypeDBCredential {
 
-    private _username: string;
-    private _password: string;
-    private _tlsRootCAPath: string;
+    private readonly _username: string;
+    private readonly _password: string;
+    private readonly _tlsRootCAPath: string;
 
     constructor(username: string, password: string, tlsRootCAPath?: string) {
         this._username = username;
@@ -40,16 +40,15 @@ export class TypeDBCredential {
         this._tlsRootCAPath = tlsRootCAPath;
     }
 
-    public username(): string {
+    get username(): string {
         return this._username;
     }
 
-    public password(): string {
+    get password(): string {
         return this._password;
     }
 
-    public tlsRootCAPath(): string {
+    get tlsRootCAPath(): string {
         return this._tlsRootCAPath;
     }
-
 }

--- a/api/connection/TypeDBSession.ts
+++ b/api/connection/TypeDBSession.ts
@@ -28,19 +28,19 @@ export interface TypeDBSession {
 
     isOpen(): boolean;
 
-    type(): SessionType;
+    readonly type: SessionType;
 
-    database(): Database;
+    readonly database: Database;
 
-    options(): TypeDBOptions;
+    readonly options: TypeDBOptions;
 
     transaction(type: TransactionType, options?: TypeDBOptions): Promise<TypeDBTransaction>;
 
     close(): Promise<void>;
-
 }
 
 export interface SessionType {
+
     proto(): Session.Type;
 
     isData(): boolean;
@@ -52,7 +52,7 @@ export namespace SessionType {
 
     class SessionTypeImpl implements SessionType {
 
-        private _type: Session.Type;
+        private readonly _type: Session.Type;
 
         constructor(type: Session.Type) {
             this._type = type;
@@ -69,7 +69,6 @@ export namespace SessionType {
         isSchema(): boolean {
             return this == SCHEMA;
         }
-
     }
 
     export const DATA = new SessionTypeImpl(Session.Type.DATA);

--- a/api/connection/TypeDBTransaction.ts
+++ b/api/connection/TypeDBTransaction.ts
@@ -19,7 +19,6 @@
  * under the License.
  */
 
-
 import { Transaction } from "typedb-protocol/common/transaction_pb";
 import { Stream } from "../../common/util/Stream";
 import { ConceptManager } from "../concept/ConceptManager";
@@ -31,26 +30,25 @@ export interface TypeDBTransaction {
 
     isOpen(): boolean;
 
-    type(): TransactionType;
+    readonly type: TransactionType;
 
-    options(): TypeDBOptions;
+    readonly options: TypeDBOptions;
 
-    concepts(): ConceptManager;
+    readonly concepts: ConceptManager;
 
-    logic(): LogicManager;
+    readonly logic: LogicManager;
 
-    query(): QueryManager;
+    readonly query: QueryManager;
 
     commit(): void;
 
     rollback(): void;
 
     close(): void;
-
 }
 
-
 export interface TransactionType {
+
     proto(): Transaction.Type;
 
     isRead(): boolean;
@@ -62,7 +60,7 @@ export namespace TransactionType {
 
     class TransactionTypeImpl implements TransactionType {
 
-        private _type: Transaction.Type;
+        private readonly _type: Transaction.Type;
 
         constructor(type: Transaction.Type) {
             this._type = type;
@@ -79,7 +77,6 @@ export namespace TransactionType {
         isWrite(): boolean {
             return this == WRITE;
         }
-
     }
 
     export const READ = new TransactionTypeImpl(Transaction.Type.READ);
@@ -93,7 +90,5 @@ export namespace TypeDBTransaction {
         rpcExecute(request: Transaction.Req, batch?: boolean): Promise<Transaction.Res>;
 
         rpcStream(request: Transaction.Req): Stream<Transaction.ResPart>;
-
     }
-
 }

--- a/api/connection/database/Database.ts
+++ b/api/connection/database/Database.ts
@@ -19,42 +19,36 @@
  * under the License.
  */
 
-
 export interface Database {
 
-    name(): string;
+    readonly name: string;
 
     delete(): Promise<void>;
 
     schema(): Promise<string>;
-
 }
 
 export namespace Database {
 
     export interface Cluster extends Database {
 
-        replicas(): Replica[];
+        readonly replicas: Replica[];
 
-        primaryReplica(): Replica;
+        readonly primaryReplica: Replica;
 
-        preferredReplica(): Replica;
-
+        readonly preferredReplica: Replica;
     }
-
 
     export interface Replica extends Database {
 
-        database(): Cluster;
+        readonly database: Cluster;
 
-        term(): number;
+        readonly term: number;
 
-        isPrimary(): boolean;
+        readonly primary: boolean;
 
-        isPreferred(): boolean;
+        readonly preferred: boolean;
 
-        address(): string;
-
+        readonly address: string;
     }
-
 }

--- a/api/connection/database/DatabaseManager.ts
+++ b/api/connection/database/DatabaseManager.ts
@@ -19,7 +19,6 @@
  * under the License.
  */
 
-
 import { Database } from "./Database";
 
 export interface DatabaseManager {
@@ -31,7 +30,6 @@ export interface DatabaseManager {
     get(name: string): Promise<Database>;
 
     all(): Promise<Database[]>;
-
 }
 
 export namespace DatabaseManager {
@@ -41,7 +39,5 @@ export namespace DatabaseManager {
         get(name: string): Promise<Database.Cluster>;
 
         all(): Promise<Database.Cluster[]>;
-
     }
-
 }

--- a/api/connection/user/User.ts
+++ b/api/connection/user/User.ts
@@ -21,10 +21,9 @@
 
 export interface User {
 
-    name(): string;
+    readonly name: string;
 
     password(password: string): Promise<void>;
 
     delete(): Promise<void>;
-
 }

--- a/api/connection/user/UserManager.ts
+++ b/api/connection/user/UserManager.ts
@@ -30,5 +30,4 @@ export interface UserManager {
     create(name: string, password: string): Promise<void>;
 
     all(): Promise<User[]>;
-
 }

--- a/api/logic/Explanation.ts
+++ b/api/logic/Explanation.ts
@@ -24,12 +24,11 @@ import { Rule } from "./Rule";
 
 export interface Explanation {
 
-    rule(): Rule;
+    readonly rule: Rule;
 
-    condition(): ConceptMap;
+    readonly condition: ConceptMap;
 
-    conclusion(): ConceptMap;
+    readonly conclusion: ConceptMap;
 
-    variableMapping(): Map<string, Set<string>>;
-
+    readonly variableMapping: Map<string, Set<string>>;
 }

--- a/api/logic/LogicManager.ts
+++ b/api/logic/LogicManager.ts
@@ -29,5 +29,4 @@ export interface LogicManager {
     getRules(): Stream<Rule>;
 
     putRule(label: string, when: string, then: string): Promise<Rule>;
-
 }

--- a/api/logic/Rule.ts
+++ b/api/logic/Rule.ts
@@ -23,16 +23,15 @@ import { TypeDBTransaction } from "../connection/TypeDBTransaction";
 
 export interface Rule {
 
-    getLabel(): string;
+    readonly label: string;
 
-    getWhen(): string;
+    readonly when: string;
 
-    getThen(): string;
+    readonly then: string;
 
     isRemote(): boolean;
 
     asRemote(transaction: TypeDBTransaction): RemoteRule;
-
 }
 
 export interface RemoteRule extends Rule {
@@ -42,5 +41,4 @@ export interface RemoteRule extends Rule {
     delete(): Promise<void>;
 
     isDeleted(): Promise<boolean>;
-
 }

--- a/api/query/QueryManager.ts
+++ b/api/query/QueryManager.ts
@@ -48,5 +48,4 @@ export interface QueryManager {
     undefine(query: string, options?: TypeDBOptions): Promise<void>;
 
     explain(explainable: ConceptMap.Explainable, options?: TypeDBOptions): Stream<Explanation>;
-
 }

--- a/common/Label.ts
+++ b/common/Label.ts
@@ -20,28 +20,28 @@
  */
 
 export class Label {
-    private _scope: string;
-    private _name: string;
+    private readonly _scope: string;
+    private readonly _name: string;
 
     constructor(scope: string, label: string) {
         this._scope = scope;
         this._name = label;
     }
 
-    scope(): string {
+    get scope(): string {
         return this._scope;
     }
 
-    name(): string {
+    get name(): string {
         return this._name;
     }
 
-    scopedName(): string {
+    get scopedName(): string {
         return this._scope == null ? this._name : `${this._scope}:${this._name}`;
     }
 
     toString() {
-        return this.scopedName();
+        return this.scopedName;
     }
 
     equals(that: Label) {
@@ -58,5 +58,4 @@ export namespace Label {
     export function scoped(scope: string, name: string) {
         return new Label(scope, name);
     }
-
 }

--- a/common/errors/TypeDBClientError.ts
+++ b/common/errors/TypeDBClientError.ts
@@ -49,7 +49,7 @@ export class TypeDBClientError extends Error {
         }
     }
 
-    errorMessage(): ErrorMessage {
+    get errorMessage(): ErrorMessage {
         return this._errorMessage;
     }
 }

--- a/common/rpc/RequestBuilder.ts
+++ b/common/rpc/RequestBuilder.ts
@@ -668,7 +668,5 @@ export namespace RequestBuilder {
                 return new AttributeProto.Value().setDateTime(value.getTime());
             }
         }
-
     }
-
 }

--- a/common/rpc/RequestBuilder.ts
+++ b/common/rpc/RequestBuilder.ts
@@ -314,8 +314,8 @@ export namespace RequestBuilder {
         }
 
         function newReqBuilder(label: Label) {
-            const builder = new TypeProto.Req().setLabel(label.name());
-            if (label.scope()) builder.setScope(label.scope());
+            const builder = new TypeProto.Req().setLabel(label.name);
+            if (label.scope) builder.setScope(label.scope);
             return builder;
         }
 
@@ -358,7 +358,7 @@ export namespace RequestBuilder {
         export namespace RoleType {
 
             export function protoRoleType(label: Label, encoding: TypeProto.Encoding) {
-                return new TypeProto().setScope(label.scope()).setLabel(label.name()).setEncoding(encoding);
+                return new TypeProto().setScope(label.scope).setLabel(label.name).setEncoding(encoding);
             }
 
             export function getRelationTypesReq(label: Label) {
@@ -377,7 +377,7 @@ export namespace RequestBuilder {
         export namespace ThingType {
 
             export function protoThingType(label: Label, encoding: TypeProto.Encoding) {
-                return new TypeProto().setLabel(label.name()).setEncoding(encoding);
+                return new TypeProto().setLabel(label.name).setEncoding(encoding);
             }
 
             export function setAbstractReq(label: Label) {

--- a/common/rpc/TypeDBStub.ts
+++ b/common/rpc/TypeDBStub.ts
@@ -34,7 +34,7 @@ export abstract class TypeDBStub {
 
     private _stub: TypeDBClient;
 
-    constructor(stub: TypeDBClient) {
+    protected constructor(stub: TypeDBClient) {
         this._stub = stub;
     }
 
@@ -105,7 +105,7 @@ export abstract class TypeDBStub {
     }
 
     transaction() {
-        return this._stub.transaction()
+        return this._stub.transaction();
     }
 
     closeClient() {

--- a/concept/answer/ConceptMapGroupImpl.ts
+++ b/concept/answer/ConceptMapGroupImpl.ts
@@ -36,14 +36,13 @@ export class ConceptMapGroupImpl implements ConceptMapGroup {
         this._conceptMaps = conceptMaps;
     }
 
-    owner(): Concept {
+    get owner(): Concept {
         return this._owner;
     }
 
-    conceptMaps(): ConceptMap[] {
+    get conceptMaps(): ConceptMap[] {
         return this._conceptMaps;
     }
-
 }
 
 export namespace ConceptMapGroupImpl {
@@ -55,5 +54,4 @@ export namespace ConceptMapGroupImpl {
         return new ConceptMapGroupImpl(owner, mapGroupProto.getConceptMapsList()
             .map((conceptMapProto) => ConceptMapImpl.of(conceptMapProto)) as ConceptMap[]);
     }
-
 }

--- a/concept/answer/ConceptMapImpl.ts
+++ b/concept/answer/ConceptMapImpl.ts
@@ -29,8 +29,8 @@ import { ThingImpl, TypeImpl } from "../../dependencies_internal";
 
 export class ConceptMapImpl implements ConceptMap {
 
-    private _concepts: Map<string, Concept>;
-    private _explainables: ConceptMap.Explainables;
+    private readonly _concepts: Map<string, Concept>;
+    private readonly _explainables: ConceptMap.Explainables;
 
     constructor(concepts: Map<string, Concept>, explainables: ConceptMap.Explainables) {
         this._concepts = concepts;
@@ -45,11 +45,11 @@ export class ConceptMapImpl implements ConceptMap {
         return this._concepts.get(variable);
     }
 
-    map(): Map<string, Concept> {
+    get map(): Map<string, Concept> {
         return this._concepts;
     }
 
-    explainables(): ConceptMap.Explainables {
+    get explainables(): ConceptMap.Explainables {
         return this._explainables;
     }
 
@@ -97,9 +97,9 @@ export namespace ConceptMapImpl {
     }
 
     export class ExplainablesImpl implements ConceptMap.Explainables {
-        private _relations: Map<string, ConceptMap.Explainable>;
-        private _attributes: Map<string, ConceptMap.Explainable>;
-        private _ownerships: Map<[string, string], ConceptMap.Explainable>;
+        private readonly _relations: Map<string, ConceptMap.Explainable>;
+        private readonly _attributes: Map<string, ConceptMap.Explainable>;
+        private readonly _ownerships: Map<[string, string], ConceptMap.Explainable>;
 
         constructor(relations: Map<string, ConceptMap.Explainable>, attributes: Map<string, ConceptMap.Explainable>,
                     ownerships: Map<[string, string], ConceptMap.Explainable>) {
@@ -127,37 +127,34 @@ export namespace ConceptMapImpl {
             throw new TypeDBClientError(NONEXISTENT_EXPLAINABLE_OWNERSHIP.message(owner, attribute));
         }
 
-        relations(): Map<string, ConceptMap.Explainable> {
+        get relations(): Map<string, ConceptMap.Explainable> {
             return this._relations;
         }
 
-        attributes(): Map<string, ConceptMap.Explainable> {
+        get attributes(): Map<string, ConceptMap.Explainable> {
             return this._attributes;
         }
 
-        ownerships(): Map<[string, string], ConceptMap.Explainable> {
+        get ownerships(): Map<[string, string], ConceptMap.Explainable> {
             return this._ownerships;
         }
-
     }
 
     export class ExplainableImpl implements ConceptMap.Explainable {
-        private _conjunction: string;
-        private _id: number;
+        private readonly _conjunction: string;
+        private readonly _id: number;
 
         constructor(conjunction: string, id: number) {
             this._conjunction = conjunction;
             this._id = id;
         }
 
-        conjunction(): string {
+        get conjunction(): string {
             return this._conjunction;
         }
 
-        id(): number {
+        get id(): number {
             return this._id;
         }
-
     }
-
 }

--- a/concept/answer/ConceptMapImpl.ts
+++ b/concept/answer/ConceptMapImpl.ts
@@ -52,7 +52,6 @@ export class ConceptMapImpl implements ConceptMap {
     get explainables(): ConceptMap.Explainables {
         return this._explainables;
     }
-
 }
 
 /* eslint no-inner-declarations: "off" */

--- a/concept/answer/NumericGroupImpl.ts
+++ b/concept/answer/NumericGroupImpl.ts
@@ -36,14 +36,13 @@ export class NumericGroupImpl implements NumericGroup {
         this._numeric = numeric;
     }
 
-    owner(): Concept {
+    get owner(): Concept {
         return this._owner;
     }
 
-    numeric(): Numeric {
+    get numeric(): Numeric {
         return this._numeric;
     }
-
 }
 
 export namespace NumericGroupImpl {
@@ -54,5 +53,4 @@ export namespace NumericGroupImpl {
         else concept = TypeImpl.of(numericGroupProto.getOwner().getType());
         return new NumericGroupImpl(concept, NumericImpl.of(numericGroupProto.getNumber()))
     }
-
 }

--- a/concept/answer/NumericImpl.ts
+++ b/concept/answer/NumericImpl.ts
@@ -68,5 +68,4 @@ export namespace NumericImpl {
                 throw new TypeDBClientError(BAD_ANSWER_TYPE.message(numericProto.getValueCase()));
         }
     }
-
 }

--- a/concept/thing/AttributeImpl.ts
+++ b/concept/thing/AttributeImpl.ts
@@ -38,8 +38,8 @@ export abstract class AttributeImpl extends ThingImpl implements Attribute {
 
     private readonly _type: AttributeType;
 
-    protected constructor(iid: string, isInferred: boolean, type: AttributeType) {
-        super(iid, isInferred);
+    protected constructor(iid: string, inferred: boolean, type: AttributeType) {
+        super(iid, inferred);
         this._type = type;
     }
 
@@ -49,11 +49,11 @@ export abstract class AttributeImpl extends ThingImpl implements Attribute {
         return true;
     }
 
-    getType(): AttributeType {
+    get type(): AttributeType {
         return this._type;
     }
 
-    abstract getValue(): boolean | string | number | Date;
+    abstract get value(): boolean | string | number | Date;
 
     isBoolean(): boolean {
         return false;
@@ -106,18 +106,18 @@ export namespace AttributeImpl {
         if (!thingProto) return null;
         const attrType = AttributeTypeImpl.of(thingProto.getType());
         const iid = Bytes.bytesToHexString(thingProto.getIid_asU8());
-        const isInferred = thingProto.getInferred();
+        const inferred = thingProto.getInferred();
         switch (thingProto.getType().getValueType()) {
             case AttributeTypeProto.ValueType.BOOLEAN:
-                return new AttributeImpl.Boolean(iid, isInferred, attrType.asBoolean(), thingProto.getValue().getBoolean());
+                return new AttributeImpl.Boolean(iid, inferred, attrType.asBoolean(), thingProto.getValue().getBoolean());
             case AttributeTypeProto.ValueType.LONG:
-                return new AttributeImpl.Long(iid, isInferred, attrType.asLong(), thingProto.getValue().getLong());
+                return new AttributeImpl.Long(iid, inferred, attrType.asLong(), thingProto.getValue().getLong());
             case AttributeTypeProto.ValueType.DOUBLE:
-                return new AttributeImpl.Double(iid, isInferred, attrType.asDouble(), thingProto.getValue().getDouble());
+                return new AttributeImpl.Double(iid, inferred, attrType.asDouble(), thingProto.getValue().getDouble());
             case AttributeTypeProto.ValueType.STRING:
-                return new AttributeImpl.String(iid, isInferred, attrType.asString(), thingProto.getValue().getString());
+                return new AttributeImpl.String(iid, inferred, attrType.asString(), thingProto.getValue().getString());
             case AttributeTypeProto.ValueType.DATETIME:
-                return new AttributeImpl.DateTime(iid, isInferred, attrType.asDateTime(), new Date(thingProto.getValue().getDateTime()));
+                return new AttributeImpl.DateTime(iid, inferred, attrType.asDateTime(), new Date(thingProto.getValue().getDateTime()));
             default:
                 throw new TypeDBClientError(BAD_VALUE_TYPE.message(thingProto.getType().getValueType()));
         }
@@ -127,25 +127,25 @@ export namespace AttributeImpl {
 
         private readonly _type: AttributeType;
 
-        protected constructor(transaction: TypeDBTransaction.Extended, iid: string, isInferred: boolean, type: AttributeType, ..._: any) {
-            super(transaction, iid, isInferred);
+        protected constructor(transaction: TypeDBTransaction.Extended, iid: string, inferred: boolean, type: AttributeType, ..._: any) {
+            super(transaction, iid, inferred);
             this._type = type;
         }
 
         abstract asRemote(transaction: TypeDBTransaction): Attribute.Remote;
 
-        getType(): AttributeType {
+        get type(): AttributeType {
             return this._type;
         }
 
-        abstract getValue(): boolean | string | number | Date;
+        abstract get value(): boolean | string | number | Date;
 
         getOwners(ownerType?: ThingType): Stream<Thing> {
             let request;
             if (!ownerType) {
-                request = RequestBuilder.Thing.Attribute.getOwnersReq(this.getIID());
+                request = RequestBuilder.Thing.Attribute.getOwnersReq(this.iid);
             } else {
-                request = RequestBuilder.Thing.Attribute.getOwnersByTypeReq(this.getIID(), ThingType.proto(ownerType));
+                request = RequestBuilder.Thing.Attribute.getOwnersByTypeReq(this.iid, ThingType.proto(ownerType));
             }
             return this.stream(request)
                 .flatMap((resPart) => Stream.array(resPart.getAttributeGetOwnersResPart().getThingsList()))
@@ -204,8 +204,8 @@ export namespace AttributeImpl {
     export class Boolean extends AttributeImpl implements Attribute.Boolean {
         private readonly _value: boolean;
 
-        constructor(iid: string, isInferred: boolean, type: AttributeType.Boolean, value: boolean) {
-            super(iid, isInferred, type);
+        constructor(iid: string, inferred: boolean, type: AttributeType.Boolean, value: boolean) {
+            super(iid, inferred, type);
             this._value = value;
         }
 
@@ -214,14 +214,14 @@ export namespace AttributeImpl {
         }
 
         asRemote(transaction: TypeDBTransaction): Attribute.Boolean.Remote {
-            return new AttributeImpl.Boolean.Remote(transaction as TypeDBTransaction.Extended, this.getIID(), this.isInferred(), this.getType(), this.getValue());
+            return new AttributeImpl.Boolean.Remote(transaction as TypeDBTransaction.Extended, this.iid, this.inferred, this.type, this.value);
         }
 
-        getType(): AttributeType.Boolean {
-            return super.getType().asBoolean();
+        get type(): AttributeType.Boolean {
+            return super.type.asBoolean();
         }
 
-        getValue(): boolean {
+        get value(): boolean {
             return this._value;
         }
 
@@ -240,8 +240,8 @@ export namespace AttributeImpl {
 
             private readonly _value: boolean;
 
-            constructor(transaction: TypeDBTransaction.Extended, iid: string, isInferred: boolean, type: AttributeType.Boolean, value: boolean) {
-                super(transaction, iid, isInferred, type);
+            constructor(transaction: TypeDBTransaction.Extended, iid: string, inferred: boolean, type: AttributeType.Boolean, value: boolean) {
+                super(transaction, iid, inferred, type);
                 this._value = value;
             }
 
@@ -250,14 +250,14 @@ export namespace AttributeImpl {
             }
 
             asRemote(transaction: TypeDBTransaction): Attribute.Boolean.Remote {
-                return new AttributeImpl.Boolean.Remote(transaction as TypeDBTransaction.Extended, this.getIID(), this.isInferred(), this.getType(), this.getValue());
+                return new AttributeImpl.Boolean.Remote(transaction as TypeDBTransaction.Extended, this.iid, this.inferred, this.type, this.value);
             }
 
-            getType(): AttributeType.Boolean {
-                return super.getType().asBoolean();
+            get type(): AttributeType.Boolean {
+                return super.type.asBoolean();
             }
 
-            getValue(): boolean {
+            get value(): boolean {
                 return this._value;
             }
 
@@ -274,8 +274,8 @@ export namespace AttributeImpl {
     export class Long extends AttributeImpl implements Attribute.Long {
         private readonly _value: number;
 
-        constructor(iid: string, isInferred: boolean, type: AttributeType.Long, value: number) {
-            super(iid, isInferred, type);
+        constructor(iid: string, inferred: boolean, type: AttributeType.Long, value: number) {
+            super(iid, inferred, type);
             this._value = value;
         }
 
@@ -284,14 +284,14 @@ export namespace AttributeImpl {
         }
 
         asRemote(transaction: TypeDBTransaction): Attribute.Long.Remote {
-            return new AttributeImpl.Long.Remote(transaction as TypeDBTransaction.Extended, this.getIID(), this.isInferred(), this.getType(), this.getValue());
+            return new AttributeImpl.Long.Remote(transaction as TypeDBTransaction.Extended, this.iid, this.inferred, this.type, this.value);
         }
 
-        getType(): AttributeType.Long {
-            return super.getType().asLong();
+        get type(): AttributeType.Long {
+            return super.type.asLong();
         }
 
-        getValue(): number {
+        get value(): number {
             return this._value;
         }
 
@@ -309,8 +309,8 @@ export namespace AttributeImpl {
         export class Remote extends AttributeImpl.Remote implements Attribute.Long.Remote {
             private readonly _value: number;
 
-            constructor(transaction: TypeDBTransaction.Extended, iid: string, isInferred: boolean, type: AttributeType.Long, value: number) {
-                super(transaction, iid, isInferred, type);
+            constructor(transaction: TypeDBTransaction.Extended, iid: string, inferred: boolean, type: AttributeType.Long, value: number) {
+                super(transaction, iid, inferred, type);
                 this._value = value;
             }
 
@@ -319,14 +319,14 @@ export namespace AttributeImpl {
             }
 
             asRemote(transaction: TypeDBTransaction): Attribute.Long.Remote {
-                return new AttributeImpl.Long.Remote(transaction as TypeDBTransaction.Extended, this.getIID(), this.isInferred(), this.getType(), this.getValue());
+                return new AttributeImpl.Long.Remote(transaction as TypeDBTransaction.Extended, this.iid, this.inferred, this.type, this.value);
             }
 
-            getType(): AttributeType.Long {
-                return super.getType().asLong();
+            get type(): AttributeType.Long {
+                return super.type.asLong();
             }
 
-            getValue(): number {
+            get value(): number {
                 return this._value;
             }
 
@@ -343,8 +343,8 @@ export namespace AttributeImpl {
     export class Double extends AttributeImpl implements Attribute.Double {
         private readonly _value: number;
 
-        constructor(iid: string, isInferred: boolean, type: AttributeType.Double, value: number) {
-            super(iid, isInferred, type);
+        constructor(iid: string, inferred: boolean, type: AttributeType.Double, value: number) {
+            super(iid, inferred, type);
             this._value = value;
         }
 
@@ -353,14 +353,14 @@ export namespace AttributeImpl {
         }
 
         asRemote(transaction: TypeDBTransaction): Attribute.Double.Remote {
-            return new AttributeImpl.Double.Remote(transaction as TypeDBTransaction.Extended, this.getIID(), this.isInferred(), this.getType(), this.getValue());
+            return new AttributeImpl.Double.Remote(transaction as TypeDBTransaction.Extended, this.iid, this.inferred, this.type, this.value);
         }
 
-        getType(): AttributeType.Double {
-            return super.getType().asDouble();
+        get type(): AttributeType.Double {
+            return super.type.asDouble();
         }
 
-        getValue(): number {
+        get value(): number {
             return this._value;
         }
 
@@ -378,8 +378,8 @@ export namespace AttributeImpl {
         export class Remote extends AttributeImpl.Remote implements Attribute.Double.Remote {
             private readonly _value: number;
 
-            constructor(transaction: TypeDBTransaction.Extended, iid: string, isInferred: boolean, type: AttributeType.Double, value: number) {
-                super(transaction, iid, isInferred, type);
+            constructor(transaction: TypeDBTransaction.Extended, iid: string, inferred: boolean, type: AttributeType.Double, value: number) {
+                super(transaction, iid, inferred, type);
                 this._value = value;
             }
 
@@ -388,14 +388,14 @@ export namespace AttributeImpl {
             }
 
             asRemote(transaction: TypeDBTransaction): Attribute.Double.Remote {
-                return new AttributeImpl.Double.Remote(transaction as TypeDBTransaction.Extended, this.getIID(), this.isInferred(), this.getType(), this.getValue());
+                return new AttributeImpl.Double.Remote(transaction as TypeDBTransaction.Extended, this.iid, this.inferred, this.type, this.value);
             }
 
-            getType(): AttributeType.Double {
-                return super.getType().asDouble();
+            get type(): AttributeType.Double {
+                return super.type.asDouble();
             }
 
-            getValue(): number {
+            get value(): number {
                 return this._value;
             }
 
@@ -412,8 +412,8 @@ export namespace AttributeImpl {
     export class String extends AttributeImpl implements Attribute.String {
         private _value: string;
 
-        constructor(iid: string, isInferred: boolean, type: AttributeType.String, value: string) {
-            super(iid, isInferred, type);
+        constructor(iid: string, inferred: boolean, type: AttributeType.String, value: string) {
+            super(iid, inferred, type);
             this._value = value;
         }
 
@@ -422,14 +422,14 @@ export namespace AttributeImpl {
         }
 
         asRemote(transaction: TypeDBTransaction): Attribute.String.Remote {
-            return new AttributeImpl.String.Remote(transaction as TypeDBTransaction.Extended, this.getIID(), this.isInferred(), this.getType(), this.getValue());
+            return new AttributeImpl.String.Remote(transaction as TypeDBTransaction.Extended, this.iid, this.inferred, this.type, this.value);
         }
 
-        getType(): AttributeType.String {
-            return super.getType().asString();
+        get type(): AttributeType.String {
+            return super.type.asString();
         }
 
-        getValue(): string {
+        get value(): string {
             return this._value;
         }
 
@@ -447,8 +447,8 @@ export namespace AttributeImpl {
         export class Remote extends AttributeImpl.Remote implements Attribute.String.Remote {
             private readonly _value: string;
 
-            constructor(transaction: TypeDBTransaction.Extended, iid: string, isInferred: boolean, type: AttributeType.String, value: string) {
-                super(transaction, iid, isInferred, type);
+            constructor(transaction: TypeDBTransaction.Extended, iid: string, inferred: boolean, type: AttributeType.String, value: string) {
+                super(transaction, iid, inferred, type);
                 this._value = value;
             }
 
@@ -457,14 +457,14 @@ export namespace AttributeImpl {
             }
 
             asRemote(transaction: TypeDBTransaction): Attribute.String.Remote {
-                return new AttributeImpl.String.Remote(transaction as TypeDBTransaction.Extended, this.getIID(), this.isInferred(), this.getType(), this.getValue());
+                return new AttributeImpl.String.Remote(transaction as TypeDBTransaction.Extended, this.iid, this.inferred, this.type, this.value);
             }
 
-            getType(): AttributeType.String {
-                return super.getType().asString();
+            get type(): AttributeType.String {
+                return super.type.asString();
             }
 
-            getValue(): string {
+            get value(): string {
                 return this._value;
             }
 
@@ -481,8 +481,8 @@ export namespace AttributeImpl {
     export class DateTime extends AttributeImpl implements Attribute.DateTime {
         private readonly _value: Date;
 
-        constructor(iid: string, isInferred: boolean, type: AttributeType.DateTime, value: Date) {
-            super(iid, isInferred, type);
+        constructor(iid: string, inferred: boolean, type: AttributeType.DateTime, value: Date) {
+            super(iid, inferred, type);
             this._value = value;
         }
 
@@ -491,14 +491,14 @@ export namespace AttributeImpl {
         }
 
         asRemote(transaction: TypeDBTransaction): Attribute.DateTime.Remote {
-            return new AttributeImpl.DateTime.Remote(transaction as TypeDBTransaction.Extended, this.getIID(), this.isInferred(), this.getType(), this.getValue());
+            return new AttributeImpl.DateTime.Remote(transaction as TypeDBTransaction.Extended, this.iid, this.inferred, this.type, this.value);
         }
 
-        getType(): AttributeType.DateTime {
-            return super.getType().asDateTime();
+        get type(): AttributeType.DateTime {
+            return super.type.asDateTime();
         }
 
-        getValue(): Date {
+        get value(): Date {
             return this._value;
         }
 
@@ -516,8 +516,8 @@ export namespace AttributeImpl {
         export class Remote extends AttributeImpl.Remote implements Attribute.DateTime.Remote {
             private readonly _value: Date;
 
-            constructor(transaction: TypeDBTransaction.Extended, iid: string, isInferred: boolean, type: AttributeType.DateTime, value: Date) {
-                super(transaction, iid, isInferred, type);
+            constructor(transaction: TypeDBTransaction.Extended, iid: string, inferred: boolean, type: AttributeType.DateTime, value: Date) {
+                super(transaction, iid, inferred, type);
                 this._value = value;
             }
 
@@ -526,14 +526,14 @@ export namespace AttributeImpl {
             }
 
             asRemote(transaction: TypeDBTransaction): Attribute.DateTime.Remote {
-                return new AttributeImpl.DateTime.Remote(transaction as TypeDBTransaction.Extended, this.getIID(), this.isInferred(), this.getType(), this.getValue());
+                return new AttributeImpl.DateTime.Remote(transaction as TypeDBTransaction.Extended, this.iid, this.inferred, this.type, this.value);
             }
 
-            getType(): AttributeType.DateTime {
-                return super.getType().asDateTime();
+            get type(): AttributeType.DateTime {
+                return super.type.asDateTime();
             }
 
-            getValue(): Date {
+            get value(): Date {
                 return this._value;
             }
 

--- a/concept/thing/EntityImpl.ts
+++ b/concept/thing/EntityImpl.ts
@@ -28,10 +28,10 @@ import { EntityTypeImpl, ThingImpl } from "../../dependencies_internal";
 
 export class EntityImpl extends ThingImpl implements Entity {
 
-    private _type: EntityType;
+    private readonly _type: EntityType;
 
-    constructor(iid: string, isInferred: boolean, type: EntityType) {
-        super(iid, isInferred);
+    constructor(iid: string, inferred: boolean, type: EntityType) {
+        super(iid, inferred);
         this._type = type;
     }
 
@@ -40,10 +40,10 @@ export class EntityImpl extends ThingImpl implements Entity {
     }
 
     asRemote(transaction: TypeDBTransaction): Entity.Remote {
-        return new EntityImpl.Remote(transaction as TypeDBTransaction.Extended, this.getIID(), this.isInferred(), this.getType());
+        return new EntityImpl.Remote(transaction as TypeDBTransaction.Extended, this.iid, this.inferred, this.type);
     }
 
-    getType(): EntityType {
+    get type(): EntityType {
         return this._type;
     }
 
@@ -68,8 +68,8 @@ export namespace EntityImpl {
 
         private readonly _type: EntityType;
 
-        constructor(transaction: TypeDBTransaction.Extended, iid: string, isInferred: boolean, type: EntityType) {
-            super(transaction, iid, isInferred);
+        constructor(transaction: TypeDBTransaction.Extended, iid: string, inferred: boolean, type: EntityType) {
+            super(transaction, iid, inferred);
             this._type = type;
         }
 
@@ -78,10 +78,10 @@ export namespace EntityImpl {
         }
 
         asRemote(transaction: TypeDBTransaction): Entity.Remote {
-            return new EntityImpl.Remote(transaction as TypeDBTransaction.Extended, this.getIID(), this.isInferred(), this.getType());
+            return new EntityImpl.Remote(transaction as TypeDBTransaction.Extended, this.iid, this.inferred, this.type);
         }
 
-        getType(): EntityType {
+        get type(): EntityType {
             return this._type;
         }
 

--- a/concept/thing/ThingImpl.ts
+++ b/concept/thing/ThingImpl.ts
@@ -39,34 +39,34 @@ import BAD_VALUE_TYPE = ErrorMessage.Concept.BAD_VALUE_TYPE;
 
 export abstract class ThingImpl extends ConceptImpl implements Thing {
     private readonly _iid: string;
-    private readonly _isInferred: boolean;
+    private readonly _inferred: boolean;
 
-    protected constructor(iid: string, isInferred: boolean) {
+    protected constructor(iid: string, inferred: boolean) {
         super();
         if (!iid) throw new TypeDBClientError(ErrorMessage.Concept.MISSING_IID);
         this._iid = iid;
-        this._isInferred = isInferred;
+        this._inferred = inferred;
     }
 
     abstract asRemote(transaction: TypeDBTransaction): Thing.Remote;
 
     equals(concept: Concept): boolean {
         if (concept.isType()) return false;
-        else return concept.asThing().getIID() === this._iid;
+        else return concept.asThing().iid === this._iid;
     }
 
     toString(): string {
         return `${this.className}[iid:${this._iid}]`;
     }
 
-    getIID(): string {
+    get iid(): string {
         return this._iid;
     }
 
-    abstract getType(): ThingType;
+    abstract get type(): ThingType;
 
-    isInferred(): boolean {
-        return this._isInferred;
+    get inferred(): boolean {
+        return this._inferred;
     }
 
     isThing(): boolean {
@@ -83,34 +83,34 @@ export namespace ThingImpl {
     export abstract class Remote extends ConceptImpl.Remote implements Thing.Remote {
 
         private readonly _iid: string;
-        private readonly _isInferred: boolean;
+        private readonly _inferred: boolean;
 
-        protected constructor(transaction: TypeDBTransaction.Extended, iid: string, isInferred: boolean, ..._: any) {
+        protected constructor(transaction: TypeDBTransaction.Extended, iid: string, inferred: boolean, ..._: any) {
             super(transaction);
             if (!iid) throw new TypeDBClientError(ErrorMessage.Concept.MISSING_IID);
             this._iid = iid;
-            this._isInferred = isInferred;
+            this._inferred = inferred;
         }
 
         abstract asRemote(transaction: TypeDBTransaction): Thing.Remote;
 
         equals(concept: Concept): boolean {
             if (concept.isType()) return false;
-            else return concept.asThing().getIID() === this._iid;
+            else return concept.asThing().iid === this._iid;
         }
 
         toString(): string {
             return `${this.className}[iid:${this._iid}]`;
         }
 
-        getIID(): string {
+        get iid(): string {
             return this._iid;
         }
 
-        abstract getType(): ThingType;
+        abstract get type(): ThingType;
 
-        isInferred(): boolean {
-            return this._isInferred;
+        get inferred(): boolean {
+            return this._inferred;
         }
 
         isThing(): boolean {
@@ -122,7 +122,7 @@ export namespace ThingImpl {
         }
 
         async delete(): Promise<void> {
-            const request = RequestBuilder.Thing.deleteReq(this.getIID());
+            const request = RequestBuilder.Thing.deleteReq(this.iid);
             await this.execute(request);
         }
 
@@ -138,14 +138,14 @@ export namespace ThingImpl {
             let isSingleAttrType = false;
             let request;
             if (typeof onlyKeyAttrTypeAttrTypes === "undefined") {
-                request = RequestBuilder.Thing.getHasReq(this.getIID(), false);
+                request = RequestBuilder.Thing.getHasReq(this.iid, false);
             } else if (typeof onlyKeyAttrTypeAttrTypes === "boolean") {
-                request = RequestBuilder.Thing.getHasReq(this.getIID(), onlyKeyAttrTypeAttrTypes);
+                request = RequestBuilder.Thing.getHasReq(this.iid, onlyKeyAttrTypeAttrTypes);
             } else if (onlyKeyAttrTypeAttrTypes instanceof Array) {
                 const attrTypesProto = onlyKeyAttrTypeAttrTypes.map((attrType) => ThingType.proto(attrType));
-                request = RequestBuilder.Thing.getHasByTypeReq(this.getIID(), attrTypesProto);
+                request = RequestBuilder.Thing.getHasByTypeReq(this.iid, attrTypesProto);
             } else {
-                request = RequestBuilder.Thing.getHasByTypeReq(this.getIID(), [ThingType.proto(onlyKeyAttrTypeAttrTypes)]);
+                request = RequestBuilder.Thing.getHasByTypeReq(this.iid, [ThingType.proto(onlyKeyAttrTypeAttrTypes)]);
                 isSingleAttrType = true;
             }
             const attributes = this.stream(request).flatMap((resPart) => Stream.array(resPart.getThingGetHasResPart().getAttributesList()))
@@ -164,7 +164,7 @@ export namespace ThingImpl {
         }
 
         getPlaying(): Stream<RoleType> {
-            const request = RequestBuilder.Thing.getPlayingReq(this.getIID());
+            const request = RequestBuilder.Thing.getPlayingReq(this.iid);
             return this.stream(request)
                 .flatMap((resPart) => Stream.array(resPart.getThingGetPlayingResPart().getRoleTypesList()))
                 .map((res) => RoleTypeImpl.of(res));
@@ -172,23 +172,23 @@ export namespace ThingImpl {
 
         getRelations(roleTypes?: RoleType[]): Stream<Relation> {
             if (!roleTypes) roleTypes = [];
-            const request = RequestBuilder.Thing.getRelationsReq(this.getIID(), roleTypes.map((roleType) => RoleType.proto(roleType)));
+            const request = RequestBuilder.Thing.getRelationsReq(this.iid, roleTypes.map((roleType) => RoleType.proto(roleType)));
             return this.stream(request)
                 .flatMap((resPart) => Stream.array(resPart.getThingGetRelationsResPart().getRelationsList()))
                 .map((res) => RelationImpl.of(res));
         }
 
         async isDeleted(): Promise<boolean> {
-            return !(await this.transaction.concepts().getThing(this.getIID()));
+            return !(await this.transaction.concepts.getThing(this.iid));
         }
 
         async setHas(attribute: Attribute): Promise<void> {
-            const request = RequestBuilder.Thing.setHasReq(this.getIID(), Thing.proto(attribute));
+            const request = RequestBuilder.Thing.setHasReq(this.iid, Thing.proto(attribute));
             await this.execute(request);
         }
 
         async unsetHas(attribute: Attribute): Promise<void> {
-            const request = RequestBuilder.Thing.unsetHasReq(this.getIID(), Thing.proto(attribute));
+            const request = RequestBuilder.Thing.unsetHasReq(this.iid, Thing.proto(attribute));
             await this.execute(request);
         }
 

--- a/concept/type/AttributeTypeImpl.ts
+++ b/concept/type/AttributeTypeImpl.ts
@@ -36,8 +36,8 @@ import INVALID_CONCEPT_CASTING = ErrorMessage.Concept.INVALID_CONCEPT_CASTING;
 
 export class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
 
-    constructor(name: string, isRoot: boolean) {
-        super(name, isRoot);
+    constructor(name: string, root: boolean) {
+        super(name, root);
     }
 
     protected get className(): string {
@@ -45,10 +45,10 @@ export class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
     }
 
     asRemote(transaction: TypeDBTransaction): AttributeType.Remote {
-        return new AttributeTypeImpl.Remote(transaction as TypeDBTransaction.Extended, this.getLabel(), this.isRoot());
+        return new AttributeTypeImpl.Remote(transaction as TypeDBTransaction.Extended, this.label, this.root);
     }
 
-    getValueType(): AttributeType.ValueType {
+    get valueType(): AttributeType.ValueType {
         return AttributeType.ValueType.OBJECT;
     }
 
@@ -81,36 +81,36 @@ export class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
     }
 
     asBoolean(): AttributeType.Boolean {
-        if (this.isRoot()) {
-            return new AttributeTypeImpl.Boolean(this.getLabel().name(), this.isRoot());
+        if (this.root) {
+            return new AttributeTypeImpl.Boolean(this.label.name, this.root);
         }
         throw new TypeDBClientError(INVALID_CONCEPT_CASTING.message(this.className, "AttributeType.Boolean"));
     }
 
     asLong(): AttributeType.Long {
-        if (this.isRoot()) {
-            return new AttributeTypeImpl.Long(this.getLabel().name(), this.isRoot());
+        if (this.root) {
+            return new AttributeTypeImpl.Long(this.label.name, this.root);
         }
         throw new TypeDBClientError(INVALID_CONCEPT_CASTING.message(this.className, "AttributeType.Long"));
     }
 
     asDouble(): AttributeType.Double {
-        if (this.isRoot()) {
-            return new AttributeTypeImpl.Double(this.getLabel().name(), this.isRoot());
+        if (this.root) {
+            return new AttributeTypeImpl.Double(this.label.name, this.root);
         }
         throw new TypeDBClientError(INVALID_CONCEPT_CASTING.message(this.className, "AttributeType.Double"));
     }
 
     asString(): AttributeType.String {
-        if (this.isRoot()) {
-            return new AttributeTypeImpl.String(this.getLabel().name(), this.isRoot());
+        if (this.root) {
+            return new AttributeTypeImpl.String(this.label.name, this.root);
         }
         throw new TypeDBClientError(INVALID_CONCEPT_CASTING.message(this.className, "AttributeType.String"));
     }
 
     asDateTime(): AttributeType.DateTime {
-        if (this.isRoot()) {
-            return new AttributeTypeImpl.DateTime(this.getLabel().name(), this.isRoot());
+        if (this.root) {
+            return new AttributeTypeImpl.DateTime(this.label.name, this.root);
         }
         throw new TypeDBClientError(INVALID_CONCEPT_CASTING.message(this.className, "AttributeType.DateTime"));
     }
@@ -139,8 +139,8 @@ export namespace AttributeTypeImpl {
 
     export class Remote extends ThingTypeImpl.Remote implements AttributeType.Remote {
 
-        constructor(transaction: TypeDBTransaction.Extended, label: Label, isRoot: boolean) {
-            super(transaction, label, isRoot);
+        constructor(transaction: TypeDBTransaction.Extended, label: Label, root: boolean) {
+            super(transaction, label, root);
         }
 
         protected get className(): string {
@@ -148,10 +148,10 @@ export namespace AttributeTypeImpl {
         }
 
         asRemote(transaction: TypeDBTransaction): AttributeType.Remote {
-            return new AttributeTypeImpl.Remote(transaction as TypeDBTransaction.Extended, this.getLabel(), this.isRoot());
+            return new AttributeTypeImpl.Remote(transaction as TypeDBTransaction.Extended, this.label, this.root);
         }
 
-        getValueType(): AttributeType.ValueType {
+        get valueType(): AttributeType.ValueType {
             return AttributeType.ValueType.OBJECT;
         }
 
@@ -184,36 +184,36 @@ export namespace AttributeTypeImpl {
         }
 
         asBoolean(): AttributeType.Boolean.Remote {
-            if (this.isRoot()) {
-                return new AttributeTypeImpl.Boolean.Remote(this.transaction, this.getLabel(), this.isRoot());
+            if (this.root) {
+                return new AttributeTypeImpl.Boolean.Remote(this.transaction, this.label, this.root);
             }
             throw new TypeDBClientError(INVALID_CONCEPT_CASTING.message(this.className, "AttributeType.Boolean"));
         }
 
         asLong(): AttributeType.Long.Remote {
-            if (this.isRoot()) {
-                return new AttributeTypeImpl.Long.Remote(this.transaction, this.getLabel(), this.isRoot());
+            if (this.root) {
+                return new AttributeTypeImpl.Long.Remote(this.transaction, this.label, this.root);
             }
             throw new TypeDBClientError(INVALID_CONCEPT_CASTING.message(this.className, "AttributeType.Long"));
         }
 
         asDouble(): AttributeType.Double.Remote {
-            if (this.isRoot()) {
-                return new AttributeTypeImpl.Double.Remote(this.transaction, this.getLabel(), this.isRoot());
+            if (this.root) {
+                return new AttributeTypeImpl.Double.Remote(this.transaction, this.label, this.root);
             }
             throw new TypeDBClientError(INVALID_CONCEPT_CASTING.message(this.className, "AttributeType.Double"));
         }
 
         asString(): AttributeType.String.Remote {
-            if (this.isRoot()) {
-                return new AttributeTypeImpl.String.Remote(this.transaction, this.getLabel(), this.isRoot());
+            if (this.root) {
+                return new AttributeTypeImpl.String.Remote(this.transaction, this.label, this.root);
             }
             throw new TypeDBClientError(INVALID_CONCEPT_CASTING.message(this.className, "AttributeType.String"));
         }
 
         asDateTime(): AttributeType.DateTime.Remote {
-            if (this.isRoot()) {
-                return new AttributeTypeImpl.DateTime.Remote(this.transaction, this.getLabel(), this.isRoot());
+            if (this.root) {
+                return new AttributeTypeImpl.DateTime.Remote(this.transaction, this.label, this.root);
             }
             throw new TypeDBClientError(INVALID_CONCEPT_CASTING.message(this.className, "AttributeType.DateTime"));
         }
@@ -231,14 +231,14 @@ export namespace AttributeTypeImpl {
         }
 
         getOwners(onlyKey?: boolean): Stream<ThingType> {
-            const request = RequestBuilder.Type.AttributeType.getOwnersReq(this.getLabel(), !!onlyKey);
+            const request = RequestBuilder.Type.AttributeType.getOwnersReq(this.label, !!onlyKey);
             return this.stream(request)
                 .flatMap((resPart) => Stream.array(resPart.getAttributeTypeGetOwnersResPart().getOwnersList()))
                 .map((thingTypeProto) => ThingTypeImpl.of(thingTypeProto));
         }
 
         protected getImpl(valueProto: AttributeProto.Value): Promise<Attribute> {
-            const request = RequestBuilder.Type.AttributeType.getReq(this.getLabel(), valueProto);
+            const request = RequestBuilder.Type.AttributeType.getReq(this.label, valueProto);
             return this.execute(request)
                 .then((attrProto) => AttributeImpl.of(attrProto.getAttributeTypeGetRes().getAttribute()));
         }
@@ -246,8 +246,8 @@ export namespace AttributeTypeImpl {
 
     export class Boolean extends AttributeTypeImpl implements AttributeType.Boolean {
 
-        constructor(label: string, isRoot: boolean) {
-            super(label, isRoot);
+        constructor(label: string, root: boolean) {
+            super(label, root);
         }
 
         protected get className(): string {
@@ -255,10 +255,10 @@ export namespace AttributeTypeImpl {
         }
 
         asRemote(transaction: TypeDBTransaction): AttributeType.Boolean.Remote {
-            return new AttributeTypeImpl.Boolean.Remote(transaction as TypeDBTransaction.Extended, this.getLabel(), this.isRoot());
+            return new AttributeTypeImpl.Boolean.Remote(transaction as TypeDBTransaction.Extended, this.label, this.root);
         }
 
-        getValueType(): AttributeType.ValueType {
+        get valueType(): AttributeType.ValueType {
             return AttributeType.ValueType.BOOLEAN;
         }
 
@@ -275,8 +275,8 @@ export namespace AttributeTypeImpl {
 
         export class Remote extends AttributeTypeImpl.Remote implements AttributeType.Boolean.Remote {
 
-            constructor(transaction: TypeDBTransaction.Extended, label: Label, isRoot: boolean) {
-                super(transaction, label, isRoot);
+            constructor(transaction: TypeDBTransaction.Extended, label: Label, root: boolean) {
+                super(transaction, label, root);
             }
 
             protected get className(): string {
@@ -284,10 +284,10 @@ export namespace AttributeTypeImpl {
             }
 
             asRemote(transaction: TypeDBTransaction): AttributeType.Boolean.Remote {
-                return new AttributeTypeImpl.Boolean.Remote(transaction as TypeDBTransaction.Extended, this.getLabel(), this.isRoot());
+                return new AttributeTypeImpl.Boolean.Remote(transaction as TypeDBTransaction.Extended, this.label, this.root);
             }
 
-            getValueType(): AttributeType.ValueType {
+            get valueType(): AttributeType.ValueType {
                 return AttributeType.ValueType.BOOLEAN;
             }
 
@@ -312,7 +312,7 @@ export namespace AttributeTypeImpl {
             }
 
             async put(value: boolean): Promise<Attribute.Boolean> {
-                const request = RequestBuilder.Type.AttributeType.putReq(this.getLabel(), RequestBuilder.Thing.Attribute.attributeValueBooleanReq(value));
+                const request = RequestBuilder.Type.AttributeType.putReq(this.label, RequestBuilder.Thing.Attribute.attributeValueBooleanReq(value));
                 return await (this.execute(request).then((res) => AttributeImpl.of(res.getAttributeTypePutRes().getAttribute())) as Promise<Attribute.Boolean>);
             }
         }
@@ -320,8 +320,8 @@ export namespace AttributeTypeImpl {
 
     export class Long extends AttributeTypeImpl implements AttributeType.Long {
 
-        constructor(label: string, isRoot: boolean) {
-            super(label, isRoot);
+        constructor(label: string, root: boolean) {
+            super(label, root);
         }
 
         protected get className(): string {
@@ -329,10 +329,10 @@ export namespace AttributeTypeImpl {
         }
 
         asRemote(transaction: TypeDBTransaction): AttributeType.Long.Remote {
-            return new AttributeTypeImpl.Long.Remote(transaction as TypeDBTransaction.Extended, this.getLabel(), this.isRoot());
+            return new AttributeTypeImpl.Long.Remote(transaction as TypeDBTransaction.Extended, this.label, this.root);
         }
 
-        getValueType(): AttributeType.ValueType {
+        get valueType(): AttributeType.ValueType {
             return AttributeType.ValueType.LONG;
         }
 
@@ -349,8 +349,8 @@ export namespace AttributeTypeImpl {
 
         export class Remote extends AttributeTypeImpl.Remote implements AttributeType.Long.Remote {
 
-            constructor(transaction: TypeDBTransaction.Extended, label: Label, isRoot: boolean) {
-                super(transaction, label, isRoot);
+            constructor(transaction: TypeDBTransaction.Extended, label: Label, root: boolean) {
+                super(transaction, label, root);
             }
 
             protected get className(): string {
@@ -358,10 +358,10 @@ export namespace AttributeTypeImpl {
             }
 
             asRemote(transaction: TypeDBTransaction): AttributeType.Long.Remote {
-                return new AttributeTypeImpl.Long.Remote(transaction as TypeDBTransaction.Extended, this.getLabel(), this.isRoot());
+                return new AttributeTypeImpl.Long.Remote(transaction as TypeDBTransaction.Extended, this.label, this.root);
             }
 
-            getValueType(): AttributeType.ValueType {
+            get valueType(): AttributeType.ValueType {
                 return AttributeType.ValueType.LONG;
             }
 
@@ -386,7 +386,7 @@ export namespace AttributeTypeImpl {
             }
 
             async put(value: number): Promise<Attribute.Long> {
-                const request = RequestBuilder.Type.AttributeType.putReq(this.getLabel(), RequestBuilder.Thing.Attribute.attributeValueLongReq(value));
+                const request = RequestBuilder.Type.AttributeType.putReq(this.label, RequestBuilder.Thing.Attribute.attributeValueLongReq(value));
                 return await (this.execute(request).then((res) => AttributeImpl.of(res.getAttributeTypePutRes().getAttribute())) as Promise<Attribute.Long>);
             }
         }
@@ -394,8 +394,8 @@ export namespace AttributeTypeImpl {
 
     export class Double extends AttributeTypeImpl implements AttributeType.Double {
 
-        constructor(label: string, isRoot: boolean) {
-            super(label, isRoot);
+        constructor(label: string, root: boolean) {
+            super(label, root);
         }
 
         protected get className(): string {
@@ -403,10 +403,10 @@ export namespace AttributeTypeImpl {
         }
 
         asRemote(transaction: TypeDBTransaction): AttributeType.Double.Remote {
-            return new AttributeTypeImpl.Double.Remote(transaction as TypeDBTransaction.Extended, this.getLabel(), this.isRoot());
+            return new AttributeTypeImpl.Double.Remote(transaction as TypeDBTransaction.Extended, this.label, this.root);
         }
 
-        getValueType(): AttributeType.ValueType {
+        get valueType(): AttributeType.ValueType {
             return AttributeType.ValueType.DOUBLE;
         }
 
@@ -423,8 +423,8 @@ export namespace AttributeTypeImpl {
 
         export class Remote extends AttributeTypeImpl.Remote implements AttributeType.Double.Remote {
 
-            constructor(transaction: TypeDBTransaction.Extended, label: Label, isRoot: boolean) {
-                super(transaction, label, isRoot);
+            constructor(transaction: TypeDBTransaction.Extended, label: Label, root: boolean) {
+                super(transaction, label, root);
             }
 
             protected get className(): string {
@@ -432,10 +432,10 @@ export namespace AttributeTypeImpl {
             }
 
             asRemote(transaction: TypeDBTransaction): AttributeType.Double.Remote {
-                return new AttributeTypeImpl.Double.Remote(transaction as TypeDBTransaction.Extended, this.getLabel(), this.isRoot());
+                return new AttributeTypeImpl.Double.Remote(transaction as TypeDBTransaction.Extended, this.label, this.root);
             }
 
-            getValueType(): AttributeType.ValueType {
+            get valueType(): AttributeType.ValueType {
                 return AttributeType.ValueType.DOUBLE;
             }
 
@@ -460,7 +460,7 @@ export namespace AttributeTypeImpl {
             }
 
             async put(value: number): Promise<Attribute.Double> {
-                const request = RequestBuilder.Type.AttributeType.putReq(this.getLabel(), RequestBuilder.Thing.Attribute.attributeValueDoubleReq(value));
+                const request = RequestBuilder.Type.AttributeType.putReq(this.label, RequestBuilder.Thing.Attribute.attributeValueDoubleReq(value));
                 return await (this.execute(request).then((res) => AttributeImpl.of(res.getAttributeTypePutRes().getAttribute())) as Promise<Attribute.Double>);
             }
         }
@@ -468,8 +468,8 @@ export namespace AttributeTypeImpl {
 
     export class String extends AttributeTypeImpl implements AttributeType.String {
 
-        constructor(label: string, isRoot: boolean) {
-            super(label, isRoot);
+        constructor(label: string, root: boolean) {
+            super(label, root);
         }
 
         protected get className(): string {
@@ -477,10 +477,10 @@ export namespace AttributeTypeImpl {
         }
 
         asRemote(transaction: TypeDBTransaction): AttributeType.String.Remote {
-            return new AttributeTypeImpl.String.Remote(transaction as TypeDBTransaction.Extended, this.getLabel(), this.isRoot())
+            return new AttributeTypeImpl.String.Remote(transaction as TypeDBTransaction.Extended, this.label, this.root)
         }
 
-        getValueType(): AttributeType.ValueType {
+        get valueType(): AttributeType.ValueType {
             return AttributeType.ValueType.STRING;
         }
 
@@ -497,8 +497,8 @@ export namespace AttributeTypeImpl {
 
         export class Remote extends AttributeTypeImpl.Remote implements AttributeType.String.Remote {
 
-            constructor(transaction: TypeDBTransaction.Extended, label: Label, isRoot: boolean) {
-                super(transaction, label, isRoot);
+            constructor(transaction: TypeDBTransaction.Extended, label: Label, root: boolean) {
+                super(transaction, label, root);
             }
 
             protected get className(): string {
@@ -506,10 +506,10 @@ export namespace AttributeTypeImpl {
             }
 
             asRemote(transaction: TypeDBTransaction): AttributeType.String.Remote {
-                return new AttributeTypeImpl.String.Remote(transaction as TypeDBTransaction.Extended, this.getLabel(), this.isRoot())
+                return new AttributeTypeImpl.String.Remote(transaction as TypeDBTransaction.Extended, this.label, this.root)
             }
 
-            getValueType(): AttributeType.ValueType {
+            get valueType(): AttributeType.ValueType {
                 return AttributeType.ValueType.STRING;
             }
 
@@ -534,17 +534,17 @@ export namespace AttributeTypeImpl {
             }
 
             async put(value: string): Promise<Attribute.String> {
-                const request = RequestBuilder.Type.AttributeType.putReq(this.getLabel(), RequestBuilder.Thing.Attribute.attributeValueStringReq(value));
+                const request = RequestBuilder.Type.AttributeType.putReq(this.label, RequestBuilder.Thing.Attribute.attributeValueStringReq(value));
                 return await (this.execute(request).then((res) => AttributeImpl.of(res.getAttributeTypePutRes().getAttribute())) as Promise<Attribute.String>);
             }
 
             async getRegex(): Promise<string> {
-                const request = RequestBuilder.Type.AttributeType.getRegexReq(this.getLabel());
+                const request = RequestBuilder.Type.AttributeType.getRegexReq(this.label);
                 return await this.execute(request).then((res) => res.getAttributeTypeGetRegexRes().getRegex());
             }
 
             async setRegex(regex: string): Promise<void> {
-                const request = RequestBuilder.Type.AttributeType.setRegexReq(this.getLabel(), regex);
+                const request = RequestBuilder.Type.AttributeType.setRegexReq(this.label, regex);
                 await this.execute(request);
             }
         }
@@ -552,8 +552,8 @@ export namespace AttributeTypeImpl {
 
     export class DateTime extends AttributeTypeImpl implements AttributeType.DateTime {
 
-        constructor(label: string, isRoot: boolean) {
-            super(label, isRoot);
+        constructor(label: string, root: boolean) {
+            super(label, root);
         }
 
         protected get className(): string {
@@ -561,10 +561,10 @@ export namespace AttributeTypeImpl {
         }
 
         asRemote(transaction: TypeDBTransaction): AttributeType.DateTime.Remote {
-            return new AttributeTypeImpl.DateTime.Remote(transaction as TypeDBTransaction.Extended, this.getLabel(), this.isRoot());
+            return new AttributeTypeImpl.DateTime.Remote(transaction as TypeDBTransaction.Extended, this.label, this.root);
         }
 
-        getValueType(): AttributeType.ValueType {
+        get valueType(): AttributeType.ValueType {
             return AttributeType.ValueType.DATETIME;
         }
 
@@ -581,8 +581,8 @@ export namespace AttributeTypeImpl {
 
         export class Remote extends AttributeTypeImpl.Remote implements AttributeType.DateTime.Remote {
 
-            constructor(transaction: TypeDBTransaction.Extended, label: Label, isRoot: boolean) {
-                super(transaction, label, isRoot);
+            constructor(transaction: TypeDBTransaction.Extended, label: Label, root: boolean) {
+                super(transaction, label, root);
             }
 
             protected get className(): string {
@@ -590,10 +590,10 @@ export namespace AttributeTypeImpl {
             }
 
             asRemote(transaction: TypeDBTransaction): AttributeType.DateTime.Remote {
-                return new AttributeTypeImpl.DateTime.Remote(transaction as TypeDBTransaction.Extended, this.getLabel(), this.isRoot());
+                return new AttributeTypeImpl.DateTime.Remote(transaction as TypeDBTransaction.Extended, this.label, this.root);
             }
 
-            getValueType(): AttributeType.ValueType {
+            get valueType(): AttributeType.ValueType {
                 return AttributeType.ValueType.DATETIME;
             }
 
@@ -618,7 +618,7 @@ export namespace AttributeTypeImpl {
             }
 
             async put(value: Date): Promise<Attribute.DateTime> {
-                const request = RequestBuilder.Type.AttributeType.putReq(this.getLabel(), RequestBuilder.Thing.Attribute.attributeValueDateTimeReq(value));
+                const request = RequestBuilder.Type.AttributeType.putReq(this.label, RequestBuilder.Thing.Attribute.attributeValueDateTimeReq(value));
                 return await (this.execute(request).then((res) => AttributeImpl.of(res.getAttributeTypePutRes().getAttribute())) as Promise<Attribute.DateTime>);
             }
         }

--- a/concept/type/EntityTypeImpl.ts
+++ b/concept/type/EntityTypeImpl.ts
@@ -30,8 +30,8 @@ import { EntityImpl, ThingTypeImpl } from "../../dependencies_internal";
 
 export class EntityTypeImpl extends ThingTypeImpl implements EntityType {
 
-    constructor(name: string, isRoot: boolean) {
-        super(name, isRoot);
+    constructor(name: string, root: boolean) {
+        super(name, root);
     }
 
     protected get className(): string {
@@ -39,7 +39,7 @@ export class EntityTypeImpl extends ThingTypeImpl implements EntityType {
     }
 
     asRemote(transaction: TypeDBTransaction): EntityType.Remote {
-        return new EntityTypeImpl.Remote(transaction as TypeDBTransaction.Extended, this.getLabel(), this.isRoot());
+        return new EntityTypeImpl.Remote(transaction as TypeDBTransaction.Extended, this.label, this.root);
     }
 
     isEntityType(): boolean {
@@ -59,8 +59,8 @@ export namespace EntityTypeImpl {
 
     export class Remote extends ThingTypeImpl.Remote implements EntityType.Remote {
 
-        constructor(transaction: TypeDBTransaction.Extended, label: Label, isRoot: boolean) {
-            super(transaction, label, isRoot);
+        constructor(transaction: TypeDBTransaction.Extended, label: Label, root: boolean) {
+            super(transaction, label, root);
         }
 
         protected get className(): string {
@@ -68,7 +68,7 @@ export namespace EntityTypeImpl {
         }
 
         asRemote(transaction: TypeDBTransaction): EntityType.Remote {
-            return new EntityTypeImpl.Remote(transaction as TypeDBTransaction.Extended, this.getLabel(), this.isRoot());
+            return new EntityTypeImpl.Remote(transaction as TypeDBTransaction.Extended, this.label, this.root);
         }
 
         isEntityType(): boolean {
@@ -80,7 +80,7 @@ export namespace EntityTypeImpl {
         }
 
         create(): Promise<Entity> {
-            const request = RequestBuilder.Type.EntityType.createReq(this.getLabel());
+            const request = RequestBuilder.Type.EntityType.createReq(this.label);
             return this.execute(request).then((res) => EntityImpl.of(res.getEntityTypeCreateRes().getEntity()));
         }
 

--- a/concept/type/RelationTypeImpl.ts
+++ b/concept/type/RelationTypeImpl.ts
@@ -31,8 +31,8 @@ import { RelationImpl, RoleTypeImpl, ThingTypeImpl } from "../../dependencies_in
 
 export class RelationTypeImpl extends ThingTypeImpl implements RelationType {
 
-    constructor(label: string, isRoot: boolean) {
-        super(label, isRoot);
+    constructor(label: string, root: boolean) {
+        super(label, root);
     }
 
     protected get className(): string {
@@ -40,7 +40,7 @@ export class RelationTypeImpl extends ThingTypeImpl implements RelationType {
     }
 
     asRemote(transaction: TypeDBTransaction): RelationType.Remote {
-        return new RelationTypeImpl.Remote(transaction as TypeDBTransaction.Extended, this.getLabel(), this.isRoot());
+        return new RelationTypeImpl.Remote(transaction as TypeDBTransaction.Extended, this.label, this.root);
     }
 
     isRelationType(): boolean {
@@ -60,8 +60,8 @@ export namespace RelationTypeImpl {
 
     export class Remote extends ThingTypeImpl.Remote implements RelationType.Remote {
 
-        constructor(transaction: TypeDBTransaction.Extended, label: Label, isRoot: boolean) {
-            super(transaction, label, isRoot);
+        constructor(transaction: TypeDBTransaction.Extended, label: Label, root: boolean) {
+            super(transaction, label, root);
         }
 
         protected get className(): string {
@@ -69,7 +69,7 @@ export namespace RelationTypeImpl {
         }
 
         asRemote(transaction: TypeDBTransaction): RelationType.Remote {
-            return new RelationTypeImpl.Remote(transaction as TypeDBTransaction.Extended, this.getLabel(), this.isRoot());
+            return new RelationTypeImpl.Remote(transaction as TypeDBTransaction.Extended, this.label, this.root);
         }
 
         isRelationType(): boolean {
@@ -81,7 +81,7 @@ export namespace RelationTypeImpl {
         }
 
         async create(): Promise<Relation> {
-            const request = RequestBuilder.Type.RelationType.createReq(this.getLabel());
+            const request = RequestBuilder.Type.RelationType.createReq(this.label);
             return this.execute(request).then((res) => RelationImpl.of(res.getRelationTypeCreateRes().getRelation()));
         }
 
@@ -101,11 +101,11 @@ export namespace RelationTypeImpl {
         getRelates(roleLabel: string): Promise<RoleType>;
         getRelates(roleLabel?: string): Promise<RoleType> | Stream<RoleType> {
             if (roleLabel) {
-                const request = RequestBuilder.Type.RelationType.getRelatesByRoleReq(this.getLabel(), roleLabel);
+                const request = RequestBuilder.Type.RelationType.getRelatesByRoleReq(this.label, roleLabel);
                 return this.execute(request)
                     .then((res) => RoleTypeImpl.of(res.getRelationTypeGetRelatesForRoleLabelRes().getRoleType()));
             } else {
-                const request = RequestBuilder.Type.RelationType.getRelatesReq(this.getLabel());
+                const request = RequestBuilder.Type.RelationType.getRelatesReq(this.label);
                 return this.stream(request)
                     .flatMap((resPart) => {
                         return Stream.array(resPart.getRelationTypeGetRelatesResPart().getRolesList())
@@ -119,15 +119,15 @@ export namespace RelationTypeImpl {
         async setRelates(roleLabel: string, overriddenLabel?: string): Promise<void> {
             let request;
             if (overriddenLabel) {
-                request = RequestBuilder.Type.RelationType.setRelatesOverriddenReq(this.getLabel(), roleLabel, overriddenLabel);
+                request = RequestBuilder.Type.RelationType.setRelatesOverriddenReq(this.label, roleLabel, overriddenLabel);
             } else {
-                request = RequestBuilder.Type.RelationType.setRelatesReq(this.getLabel(), roleLabel);
+                request = RequestBuilder.Type.RelationType.setRelatesReq(this.label, roleLabel);
             }
             await this.execute(request);
         }
 
         async unsetRelates(roleLabel: string): Promise<void> {
-            const request = RequestBuilder.Type.RelationType.unsetRelatesReq(this.getLabel(), roleLabel);
+            const request = RequestBuilder.Type.RelationType.unsetRelatesReq(this.label, roleLabel);
             await this.execute(request);
         }
     }

--- a/concept/type/RoleTypeImpl.ts
+++ b/concept/type/RoleTypeImpl.ts
@@ -31,8 +31,8 @@ import { RelationTypeImpl, ThingTypeImpl, TypeImpl } from "../../dependencies_in
 
 export class RoleTypeImpl extends TypeImpl implements RoleType {
 
-    constructor(scope: string, label: string, isRoot: boolean) {
-        super(Label.scoped(scope, label), isRoot);
+    constructor(scope: string, label: string, root: boolean) {
+        super(Label.scoped(scope, label), root);
     }
 
     protected get className(): string {
@@ -40,7 +40,7 @@ export class RoleTypeImpl extends TypeImpl implements RoleType {
     }
 
     asRemote(transaction: TypeDBTransaction): RoleType.Remote {
-        return new RoleTypeImpl.Remote(transaction as TypeDBTransaction.Extended, this.getLabel(), this.isRoot());
+        return new RoleTypeImpl.Remote(transaction as TypeDBTransaction.Extended, this.label, this.root);
     }
 
     isRoleType(): boolean {
@@ -61,8 +61,8 @@ export namespace RoleTypeImpl {
 
     export class Remote extends TypeImpl.Remote implements RoleType.Remote {
 
-        constructor(transaction: TypeDBTransaction.Extended, label: Label, isRoot: boolean) {
-            super(transaction, label, isRoot);
+        constructor(transaction: TypeDBTransaction.Extended, label: Label, root: boolean) {
+            super(transaction, label, root);
         }
 
         protected get className(): string {
@@ -70,7 +70,7 @@ export namespace RoleTypeImpl {
         }
 
         asRemote(transaction: TypeDBTransaction): RoleType.Remote {
-            return new RoleTypeImpl.Remote(transaction as TypeDBTransaction.Extended, this.getLabel(), this.isRoot());
+            return new RoleTypeImpl.Remote(transaction as TypeDBTransaction.Extended, this.label, this.root);
         }
 
         isRoleType(): boolean {
@@ -94,18 +94,18 @@ export namespace RoleTypeImpl {
         }
 
         getRelationType(): Promise<RelationType> {
-            return this.transaction.concepts().getRelationType(this.getLabel().scope());
+            return this.transaction.concepts.getRelationType(this.label.scope);
         }
 
         getRelationTypes(): Stream<RelationType> {
-            const request = RequestBuilder.Type.RoleType.getRelationTypesReq(this.getLabel());
+            const request = RequestBuilder.Type.RoleType.getRelationTypesReq(this.label);
             return this.stream(request)
                 .flatMap((resPart) => Stream.array(resPart.getRoleTypeGetRelationTypesResPart().getRelationTypesList()))
                 .map((res) => RelationTypeImpl.of(res));
         }
 
         getPlayers(): Stream<ThingType> {
-            const request = RequestBuilder.Type.RoleType.getPlayersReq(this.getLabel());
+            const request = RequestBuilder.Type.RoleType.getPlayersReq(this.label);
             return this.stream(request)
                 .flatMap((resPart) => Stream.array(resPart.getRoleTypeGetPlayersResPart().getThingTypesList()))
                 .map((thing) => ThingTypeImpl.of(thing));
@@ -113,7 +113,7 @@ export namespace RoleTypeImpl {
 
         async isDeleted(): Promise<boolean> {
             const relationType = await this.getRelationType();
-            return !(relationType) || (!(await relationType.asRemote(this.transaction).getRelates(this.getLabel().name())));
+            return !(relationType) || (!(await relationType.asRemote(this.transaction).getRelates(this.label.name)));
         }
     }
 }

--- a/concept/type/ThingTypeImpl.ts
+++ b/concept/type/ThingTypeImpl.ts
@@ -35,8 +35,8 @@ import BAD_ENCODING = ErrorMessage.Concept.BAD_ENCODING;
 
 export class ThingTypeImpl extends TypeImpl implements ThingType {
 
-    constructor(name: string, isRoot: boolean) {
-        super(Label.of(name), isRoot);
+    constructor(name: string, root: boolean) {
+        super(Label.of(name), root);
     }
 
     protected get className(): string {
@@ -44,7 +44,7 @@ export class ThingTypeImpl extends TypeImpl implements ThingType {
     }
 
     asRemote(transaction: TypeDBTransaction): ThingType.Remote {
-        return new ThingTypeImpl.Remote(transaction as TypeDBTransaction.Extended, this.getLabel(), this.isRoot());
+        return new ThingTypeImpl.Remote(transaction as TypeDBTransaction.Extended, this.label, this.root);
     }
 
     isThingType(): boolean {
@@ -76,8 +76,8 @@ export namespace ThingTypeImpl {
 
     export class Remote extends TypeImpl.Remote implements ThingType.Remote {
 
-        constructor(transaction: TypeDBTransaction.Extended, label: Label, isRoot: boolean) {
-            super(transaction, label, isRoot);
+        constructor(transaction: TypeDBTransaction.Extended, label: Label, root: boolean) {
+            super(transaction, label, root);
         }
 
         protected get className(): string {
@@ -85,7 +85,7 @@ export namespace ThingTypeImpl {
         }
 
         asRemote(transaction: TypeDBTransaction): ThingType.Remote {
-            return new ThingTypeImpl.Remote(transaction as TypeDBTransaction.Extended, this.getLabel(), this.isRoot());
+            return new ThingTypeImpl.Remote(transaction as TypeDBTransaction.Extended, this.label, this.root);
         }
 
         isThingType(): boolean {
@@ -109,7 +109,7 @@ export namespace ThingTypeImpl {
         }
 
         getInstances(): Stream<Thing> {
-            const request = RequestBuilder.Type.ThingType.getInstancesReq(this.getLabel());
+            const request = RequestBuilder.Type.ThingType.getInstancesReq(this.label);
             return this.stream(request)
                 .flatMap((resPart) => Stream.array(resPart.getThingTypeGetInstancesResPart().getThingsList()))
                 .map((thingProto) => ThingImpl.of(thingProto));
@@ -122,16 +122,16 @@ export namespace ThingTypeImpl {
         getOwns(valueTypeOrKeysOnly?: AttributeType.ValueType | boolean, keysOnly?: boolean): Stream<AttributeType> {
             let request;
             if (!valueTypeOrKeysOnly) {
-                request = RequestBuilder.Type.ThingType.getOwnsReq(this.getLabel(), false);
+                request = RequestBuilder.Type.ThingType.getOwnsReq(this.label, false);
             } else if (typeof valueTypeOrKeysOnly === "boolean") {
-                request = RequestBuilder.Type.ThingType.getOwnsReq(this.getLabel(), valueTypeOrKeysOnly as boolean)
+                request = RequestBuilder.Type.ThingType.getOwnsReq(this.label, valueTypeOrKeysOnly as boolean)
             } else if (!keysOnly) {
                 request = RequestBuilder.Type.ThingType.getOwnsByTypeReq(
-                    this.getLabel(), (valueTypeOrKeysOnly as AttributeType.ValueType).proto(), false
+                    this.label, (valueTypeOrKeysOnly as AttributeType.ValueType).proto(), false
                 );
             } else {
                 request = RequestBuilder.Type.ThingType.getOwnsByTypeReq(
-                    this.getLabel(), (valueTypeOrKeysOnly as AttributeType.ValueType).proto(), keysOnly
+                    this.label, (valueTypeOrKeysOnly as AttributeType.ValueType).proto(), keysOnly
                 );
             }
             return this.stream(request)
@@ -145,28 +145,28 @@ export namespace ThingTypeImpl {
         async setOwns(attributeType: AttributeType, overriddenTypeOrIsKey?: AttributeType | boolean, isKey?: boolean): Promise<void> {
             let request;
             if (!overriddenTypeOrIsKey) {
-                request = RequestBuilder.Type.ThingType.setOwnsReq(this.getLabel(), ThingType.proto(attributeType), false);
+                request = RequestBuilder.Type.ThingType.setOwnsReq(this.label, ThingType.proto(attributeType), false);
             } else if (typeof overriddenTypeOrIsKey === "boolean") {
-                request = RequestBuilder.Type.ThingType.setOwnsReq(this.getLabel(), ThingType.proto(attributeType), overriddenTypeOrIsKey as boolean)
+                request = RequestBuilder.Type.ThingType.setOwnsReq(this.label, ThingType.proto(attributeType), overriddenTypeOrIsKey as boolean)
             } else if (!isKey) {
                 request = RequestBuilder.Type.ThingType.setOwnsOverriddenReq(
-                    this.getLabel(), ThingType.proto(attributeType), ThingType.proto((overriddenTypeOrIsKey as AttributeType)), false
+                    this.label, ThingType.proto(attributeType), ThingType.proto((overriddenTypeOrIsKey as AttributeType)), false
                 );
             } else {
                 request = RequestBuilder.Type.ThingType.setOwnsOverriddenReq(
-                    this.getLabel(), ThingType.proto(attributeType), ThingType.proto(overriddenTypeOrIsKey as AttributeType), isKey
+                    this.label, ThingType.proto(attributeType), ThingType.proto(overriddenTypeOrIsKey as AttributeType), isKey
                 );
             }
             await this.execute(request);
         }
 
         async unsetOwns(attributeType: AttributeType): Promise<void> {
-            const request = RequestBuilder.Type.ThingType.unsetOwnsReq(this.getLabel(), ThingType.proto(attributeType));
+            const request = RequestBuilder.Type.ThingType.unsetOwnsReq(this.label, ThingType.proto(attributeType));
             await this.execute(request);
         }
 
         getPlays(): Stream<RoleType> {
-            const request = RequestBuilder.Type.ThingType.getPlaysReq(this.getLabel());
+            const request = RequestBuilder.Type.ThingType.getPlaysReq(this.label);
             return this.stream(request)
                 .flatMap((resPart) => Stream.array(resPart.getThingTypeGetPlaysResPart().getRolesList()))
                 .map((roleProto) => RoleTypeImpl.of(roleProto));
@@ -176,34 +176,34 @@ export namespace ThingTypeImpl {
         async setPlays(role: RoleType, overriddenType?: RoleType): Promise<void> {
             let request;
             if (!overriddenType) {
-                request = RequestBuilder.Type.ThingType.setPlaysReq(this.getLabel(), RoleType.proto(role));
+                request = RequestBuilder.Type.ThingType.setPlaysReq(this.label, RoleType.proto(role));
             } else {
-                request = RequestBuilder.Type.ThingType.setPlaysOverriddenReq(this.getLabel(), RoleType.proto(role), RoleType.proto(overriddenType));
+                request = RequestBuilder.Type.ThingType.setPlaysOverriddenReq(this.label, RoleType.proto(role), RoleType.proto(overriddenType));
             }
             await this.execute(request);
         }
 
         async unsetPlays(role: RoleType): Promise<void> {
-            const request = RequestBuilder.Type.ThingType.unsetPlaysReq(this.getLabel(), RoleType.proto(role));
+            const request = RequestBuilder.Type.ThingType.unsetPlaysReq(this.label, RoleType.proto(role));
             await this.execute(request);
         }
 
         async setAbstract(): Promise<void> {
-            const request = RequestBuilder.Type.ThingType.setAbstractReq(this.getLabel());
+            const request = RequestBuilder.Type.ThingType.setAbstractReq(this.label);
             await this.execute(request);
         }
 
         async unsetAbstract(): Promise<void> {
-            const request = RequestBuilder.Type.ThingType.unsetAbstractReq(this.getLabel());
+            const request = RequestBuilder.Type.ThingType.unsetAbstractReq(this.label);
             await this.execute(request);
         }
 
         async isDeleted(): Promise<boolean> {
-            return (await this.transaction.concepts().getThingType(this.getLabel().name())) != null;
+            return (await this.transaction.concepts.getThingType(this.label.name)) != null;
         }
 
         protected async setSupertype(thingType: ThingType): Promise<void> {
-            const request = RequestBuilder.Type.ThingType.setSupertypeReq(this.getLabel(), ThingType.proto(thingType));
+            const request = RequestBuilder.Type.ThingType.setSupertypeReq(this.label, ThingType.proto(thingType));
             await this.execute(request);
         }
     }

--- a/concept/type/TypeImpl.ts
+++ b/concept/type/TypeImpl.ts
@@ -35,22 +35,22 @@ import MISSING_LABEL = ErrorMessage.Concept.MISSING_LABEL;
 export abstract class TypeImpl extends ConceptImpl implements Type {
 
     private readonly _label: Label;
-    private readonly _isRoot: boolean;
+    private readonly _root: boolean;
 
-    protected constructor(label: Label, isRoot: boolean) {
+    protected constructor(label: Label, root: boolean) {
         super();
         if (!label) throw new TypeDBClientError(MISSING_LABEL);
         this._label = label;
-        this._isRoot = isRoot;
+        this._root = root;
     }
 
     abstract asRemote(transaction: TypeDBTransaction): Type.Remote;
 
-    isRoot(): boolean {
-        return this._isRoot;
+    get root(): boolean {
+        return this._root;
     }
 
-    getLabel(): Label {
+    get label(): Label {
         return this._label;
     }
 
@@ -64,7 +64,7 @@ export abstract class TypeImpl extends ConceptImpl implements Type {
 
     equals(concept: Concept): boolean {
         if (!concept.isType()) return false;
-        return concept.asType().getLabel().equals(this.getLabel());
+        return concept.asType().label.equals(this.label);
     }
 
     toString(): string {
@@ -85,22 +85,22 @@ export namespace TypeImpl {
     export abstract class Remote extends ConceptImpl.Remote implements Type.Remote {
 
         private _label: Label;
-        private readonly _isRoot: boolean;
+        private readonly _root: boolean;
 
-        protected constructor(transaction: TypeDBTransaction.Extended, label: Label, isRoot: boolean) {
+        protected constructor(transaction: TypeDBTransaction.Extended, label: Label, root: boolean) {
             super(transaction);
             if (!label) throw new TypeDBClientError(ErrorMessage.Concept.MISSING_LABEL);
             this._label = label;
-            this._isRoot = isRoot;
+            this._root = root;
         }
 
         abstract asRemote(transaction: TypeDBTransaction): Type.Remote;
 
-        isRoot(): boolean {
-            return this._isRoot;
+        get root(): boolean {
+            return this._root;
         }
 
-        getLabel(): Label {
+        get label(): Label {
             return this._label;
         }
 
@@ -114,7 +114,7 @@ export namespace TypeImpl {
 
         equals(concept: Concept): boolean {
             if (!concept.isType()) return false;
-            return (concept as Type).getLabel().equals(this.getLabel());
+            return (concept as Type).label.equals(this.label);
         }
 
         toString(): string {
@@ -148,7 +148,7 @@ export namespace TypeImpl {
         async setLabel(label: string): Promise<void> {
             const request = RequestBuilder.Type.setLabelReq(this._label, label);
             await this.execute(request);
-            this._label = new Label(this.getLabel().scope(), label);
+            this._label = new Label(this.label.scope, label);
         }
 
         async isAbstract(): Promise<boolean> {

--- a/connection/TypeDBClientImpl.ts
+++ b/connection/TypeDBClientImpl.ts
@@ -60,7 +60,7 @@ export abstract class TypeDBClientImpl implements TypeDBClient {
         throw new TypeDBClientError(ILLEGAL_CAST.message(this.constructor.toString(), "ClusterClient"));
     }
 
-    databases(): TypeDBDatabaseManagerImpl {
+    get databases(): TypeDBDatabaseManagerImpl {
         return this._databases;
     }
 
@@ -68,8 +68,8 @@ export abstract class TypeDBClientImpl implements TypeDBClient {
         if (!options) options = TypeDBOptions.core();
         const session = new TypeDBSessionImpl(database, type, options, this);
         await session.open();
-        if (this._sessions[session.sessionId()]) throw new TypeDBClientError(SESSION_ID_EXISTS.message(session.sessionId()));
-        this._sessions[session.sessionId()] = session;
+        if (this._sessions[session.id]) throw new TypeDBClientError(SESSION_ID_EXISTS.message(session.id));
+        this._sessions[session.id] = session;
         return session;
     }
 
@@ -83,7 +83,7 @@ export abstract class TypeDBClientImpl implements TypeDBClient {
     }
 
     closedSession(session: TypeDBSessionImpl): void {
-        delete this._sessions[session.sessionId()];
+        delete this._sessions[session.id];
     }
 
     stub(): TypeDBStub {
@@ -93,5 +93,4 @@ export abstract class TypeDBClientImpl implements TypeDBClient {
     transmitter(): RequestTransmitter {
         return this._requestTransmitter;
     }
-
 }

--- a/connection/TypeDBDatabaseImpl.ts
+++ b/connection/TypeDBDatabaseImpl.ts
@@ -35,7 +35,7 @@ export class TypeDBDatabaseImpl implements Database {
         this._stub = typeDBStub;
     }
 
-    name(): string {
+    get name(): string {
         return this._name;
     }
 
@@ -46,12 +46,11 @@ export class TypeDBDatabaseImpl implements Database {
     }
 
     schema(): Promise<string> {
-        const req = RequestBuilder.Core.Database.schemaReq(this.name());
+        const req = RequestBuilder.Core.Database.schemaReq(this.name);
         return this._stub.databaseSchema(req);
     }
 
     toString(): string {
         return "Database[" + this._name + "]";
     }
-
 }

--- a/connection/TypeDBDatabaseManagerImpl.ts
+++ b/connection/TypeDBDatabaseManagerImpl.ts
@@ -60,5 +60,4 @@ export class TypeDBDatabaseManagerImpl implements DatabaseManager {
     stub() {
         return this._stub;
     }
-
 }

--- a/connection/TypeDBStubFactory.ts
+++ b/connection/TypeDBStubFactory.ts
@@ -24,5 +24,4 @@ import { TypeDBStub } from "../common/rpc/TypeDBStub";
 export abstract class TypeDBStubFactory {
 
     abstract newTypeDBStub(address: string): TypeDBStub;
-
 }

--- a/connection/TypeDBTransactionImpl.ts
+++ b/connection/TypeDBTransactionImpl.ts
@@ -38,28 +38,26 @@ import TRANSACTION_CLOSED = ErrorMessage.Client.TRANSACTION_CLOSED;
 
 export class TypeDBTransactionImpl implements TypeDBTransaction.Extended {
     private readonly _session: TypeDBSessionImpl;
-    private readonly _sessionId: string;
     private readonly _type: TransactionType;
     private readonly _options: TypeDBOptions;
     private _bidirectionalStream: BidirectionalStream;
-    private _conceptManager: ConceptManager;
-    private _logicManager: LogicManager;
-    private _queryManager: QueryManager;
+    private readonly _conceptManager: ConceptManager;
+    private readonly _logicManager: LogicManager;
+    private readonly _queryManager: QueryManager;
 
-    constructor(session: TypeDBSessionImpl, _sessionId: string, type: TransactionType, options: TypeDBOptions) {
+    constructor(session: TypeDBSessionImpl, type: TransactionType, options: TypeDBOptions) {
         this._session = session;
-        this._sessionId = _sessionId;
         this._type = type;
         this._options = options;
-        const rpcClient = this._session.stub();
-        this._bidirectionalStream = new BidirectionalStream(rpcClient, this._session.requestTransmitter());
+        const rpcClient = this._session.stub;
+        this._bidirectionalStream = new BidirectionalStream(rpcClient, this._session.requestTransmitter);
         this._conceptManager = new ConceptManagerImpl(this);
         this._logicManager = new LogicManagerImpl(this);
         this._queryManager = new QueryManagerImpl(this);
     }
 
     public async open(): Promise<void> {
-        const openReq = RequestBuilder.Transaction.openReq(this._sessionId, this._type.proto(), this._options.proto(), this._session.networkLatency());
+        const openReq = RequestBuilder.Transaction.openReq(this._session.id, this._type.proto(), this._options.proto(), this._session.networkLatency);
         await this.rpcExecute(openReq, false);
     }
 
@@ -81,23 +79,23 @@ export class TypeDBTransactionImpl implements TypeDBTransaction.Extended {
         await this.rpcExecute(rollbackReq, false);
     }
 
-    public concepts(): ConceptManager {
+    public get concepts(): ConceptManager {
         return this._conceptManager;
     }
 
-    public logic(): LogicManager {
+    public get logic(): LogicManager {
         return this._logicManager;
     }
 
-    public query(): QueryManager {
+    public get query(): QueryManager {
         return this._queryManager;
     }
 
-    public options(): TypeDBOptions {
+    public get options(): TypeDBOptions {
         return this._options;
     }
 
-    public type(): TransactionType {
+    public get type(): TransactionType {
         return this._type;
     }
 
@@ -115,5 +113,4 @@ export class TypeDBTransactionImpl implements TypeDBTransaction.Extended {
         if (!this.isOpen()) throw new TypeDBClientError(TRANSACTION_CLOSED);
         return this._bidirectionalStream.stream(request);
     }
-
 }

--- a/connection/cluster/ClusterClient.ts
+++ b/connection/cluster/ClusterClient.ts
@@ -19,7 +19,6 @@
  * under the License.
  */
 
-
 import { Database } from "../../api/connection/database/Database";
 import { TypeDBClient } from "../../api/connection/TypeDBClient";
 import { TypeDBCredential } from "../../api/connection/TypeDBCredential";
@@ -79,11 +78,11 @@ export class ClusterClient implements TypeDBClient.Cluster {
         }
     }
 
-    databases(): ClusterDatabaseManager {
+    get databases(): ClusterDatabaseManager {
         return this._databaseManagers;
     }
 
-    users(): ClusterUserManager {
+    get users(): ClusterUserManager {
         return this._userManager;
     }
 
@@ -149,7 +148,6 @@ export class ClusterClient implements TypeDBClient.Cluster {
         }
         throw new TypeDBClientError(CLUSTER_UNABLE_TO_CONNECT.message(this._addresses.join(",")));
     }
-
 }
 
 class OpenSessionFailsafeTask extends FailsafeTask<ClusterSession> {
@@ -163,7 +161,7 @@ class OpenSessionFailsafeTask extends FailsafeTask<ClusterSession> {
     }
 
     run(replica: Database.Replica): Promise<ClusterSession> {
-        const session = new ClusterSession(this.client, replica.address());
-        return session.open(replica.address(), this.database, this._type, this._options);
+        const session = new ClusterSession(this.client, replica.address);
+        return session.open(replica.address, this.database, this._type, this._options);
     }
 }

--- a/connection/cluster/ClusterDatabaseManager.ts
+++ b/connection/cluster/ClusterDatabaseManager.ts
@@ -42,7 +42,7 @@ export class ClusterDatabaseManager implements DatabaseManager.Cluster {
     constructor(client: ClusterClient) {
         this._client = client;
         this._databaseManagers = Object.entries(this._client.clusterServerClients()).reduce((obj: { [address: string]: TypeDBDatabaseManagerImpl }, [addr, client]) => {
-            obj[addr] = client.databases();
+            obj[addr] = client.databases;
             return obj;
         }, {});
     }
@@ -91,7 +91,7 @@ export class ClusterDatabaseManager implements DatabaseManager.Cluster {
         try {
             return await failsafeTask.runAnyReplica();
         } catch (e) {
-            if (e instanceof TypeDBClientError && CLUSTER_REPLICA_NOT_PRIMARY === e.errorMessage()) {
+            if (e instanceof TypeDBClientError && CLUSTER_REPLICA_NOT_PRIMARY === e.errorMessage) {
                 return await failsafeTask.runPrimaryReplica();
             } else throw e;
         }
@@ -108,6 +108,6 @@ class DatabaseManagerFailsafeTask<T> extends FailsafeTask<T> {
     }
 
     async run(replica: Database.Replica): Promise<T> {
-        return this._task(this.client.stub(replica.address()), this.client.clusterServerClient(replica.address()).databases());
+        return this._task(this.client.stub(replica.address), this.client.clusterServerClient(replica.address).databases);
     }
 }

--- a/connection/cluster/ClusterServerClient.ts
+++ b/connection/cluster/ClusterServerClient.ts
@@ -28,5 +28,4 @@ export class ClusterServerClient extends TypeDBClientImpl {
     constructor(address: string, credential: TypeDBCredential) {
         super(address, new ClusterServerStubFactory(credential));
     }
-
 }

--- a/connection/cluster/ClusterServerStub.ts
+++ b/connection/cluster/ClusterServerStub.ts
@@ -117,15 +117,15 @@ export namespace ClusterServerStub {
     export function create(address: string, credential: TypeDBCredential) {
         const metaCallback = (_params: any, callback: any) => {
             const meta = new Metadata();
-            meta.add('username', credential.username());
-            meta.add('password', credential.password());
+            meta.add('username', credential.username);
+            meta.add('password', credential.password);
             callback(null, meta);
         }
         const callCreds = CallCredentials.createFromMetadataGenerator(metaCallback);
 
         let stubCredentials;
-        if (credential.tlsRootCAPath() != null) {
-            const rootCert = fs.readFileSync(credential.tlsRootCAPath());
+        if (credential.tlsRootCAPath != null) {
+            const rootCert = fs.readFileSync(credential.tlsRootCAPath);
             stubCredentials = credentials.combineChannelCredentials(ChannelCredentials.createSsl(rootCert), callCreds);
         } else {
             stubCredentials = credentials.combineChannelCredentials(ChannelCredentials.createSsl(), callCreds);

--- a/connection/cluster/ClusterServerStubFactory.ts
+++ b/connection/cluster/ClusterServerStubFactory.ts
@@ -25,7 +25,7 @@ import { ClusterServerStub } from "./ClusterServerStub";
 
 export class ClusterServerStubFactory extends TypeDBStubFactory {
 
-    private _credential: TypeDBCredential;
+    private readonly _credential: TypeDBCredential;
 
     constructor(credential: TypeDBCredential) {
         super();
@@ -35,5 +35,4 @@ export class ClusterServerStubFactory extends TypeDBStubFactory {
     newTypeDBStub(address: string): ClusterServerStub {
         return ClusterServerStub.create(address, this._credential);
     }
-
 }

--- a/connection/cluster/ClusterSession.ts
+++ b/connection/cluster/ClusterSession.ts
@@ -73,15 +73,15 @@ export class ClusterSession implements TypeDBSession {
         }
     }
 
-    type(): SessionType {
-        return this._typeDBSession.type();
+    get type(): SessionType {
+        return this._typeDBSession.type;
     }
 
     isOpen(): boolean {
         return this._typeDBSession.isOpen();
     }
 
-    options(): TypeDBClusterOptions {
+    get options(): TypeDBClusterOptions {
         return this._options;
     }
 
@@ -89,8 +89,8 @@ export class ClusterSession implements TypeDBSession {
         return this._typeDBSession.close();
     }
 
-    database(): Database {
-        return this._typeDBSession.database();
+    get database(): Database {
+        return this._typeDBSession.database;
     }
 
     clusterClient(): ClusterClient {
@@ -112,7 +112,7 @@ class TransactionFailsafeTask extends FailsafeTask<TypeDBTransaction> {
     private readonly _options: TypeDBClusterOptions;
 
     constructor(clusterSession: ClusterSession, type: TransactionType, options: TypeDBClusterOptions) {
-        super(clusterSession.clusterClient(), clusterSession.database().name());
+        super(clusterSession.clusterClient(), clusterSession.database.name);
         this._clusterSession = clusterSession;
         this._type = type;
         this._options = options;
@@ -124,8 +124,8 @@ class TransactionFailsafeTask extends FailsafeTask<TypeDBTransaction> {
 
     async rerun(replica: Database.Replica): Promise<TypeDBTransaction> {
         if (this._clusterSession.typeDBSession) await this._clusterSession.typeDBSession.close();
-        this._clusterSession.clusterServerClient = this._clusterSession.clusterClient().clusterServerClient(replica.address());
-        this._clusterSession.typeDBSession = await this._clusterSession.clusterServerClient.session(this.database, this._clusterSession.type(), this._clusterSession.options());
+        this._clusterSession.clusterServerClient = this._clusterSession.clusterClient().clusterServerClient(replica.address);
+        this._clusterSession.typeDBSession = await this._clusterSession.clusterServerClient.session(this.database, this._clusterSession.type, this._clusterSession.options);
         return await this._clusterSession.typeDBSession.transaction(this._type, this._options);
     }
 }

--- a/connection/cluster/ClusterUser.ts
+++ b/connection/cluster/ClusterUser.ts
@@ -27,8 +27,8 @@ import { ClusterClient } from "./ClusterClient";
 
 export class ClusterUser implements User {
 
-    private _client: ClusterClient;
-    private _name: string;
+    private readonly _client: ClusterClient;
+    private readonly _name: string;
 
     constructor(client: ClusterClient, name: string) {
         this._client = client;
@@ -37,19 +37,19 @@ export class ClusterUser implements User {
 
     async password(password: string): Promise<void> {
         const failsafeTask = new ClusterUserFailsafeTask(this._client, (replica) => {
-            return this._client.stub(replica.address()).userPassword(RequestBuilder.Cluster.User.passwordReq(this.name(), password));
+            return this._client.stub(replica.address).userPassword(RequestBuilder.Cluster.User.passwordReq(this.name, password));
         });
         await failsafeTask.runPrimaryReplica();
     }
 
     async delete(): Promise<void> {
         const failsafeTask = new ClusterUserFailsafeTask(this._client, (replica) => {
-            return this._client.stub(replica.address()).userDelete(RequestBuilder.Cluster.User.deleteReq(this.name()));
+            return this._client.stub(replica.address).userDelete(RequestBuilder.Cluster.User.deleteReq(this.name));
         });
         await failsafeTask.runPrimaryReplica();
     }
 
-    name(): string {
+    get name(): string {
         return this._name;
     }
 }
@@ -66,5 +66,4 @@ class ClusterUserFailsafeTask<T> extends FailsafeTask<T> {
     run(replica: Database.Replica): Promise<T> {
         return this._task(replica);
     }
-
 }

--- a/connection/cluster/ClusterUserManager.ts
+++ b/connection/cluster/ClusterUserManager.ts
@@ -40,7 +40,7 @@ export class ClusterUserManager implements UserManager {
 
     all(): Promise<User[]> {
         const failsafeTask = new UserManagerFailsafeTask(this._client, (replica: Database.Replica) => {
-            return this._client.stub(replica.address()).usersAll(RequestBuilder.Cluster.UserManager.allReq())
+            return this._client.stub(replica.address).usersAll(RequestBuilder.Cluster.UserManager.allReq())
                 .then((res) => {
                     return res.getNamesList().map(name => new ClusterUser(this._client, name));
                 });
@@ -50,14 +50,14 @@ export class ClusterUserManager implements UserManager {
 
     contains(name: string): Promise<boolean> {
         const failsafeTask = new UserManagerFailsafeTask(this._client, (replica: Database.Replica) => {
-            return this._client.stub(replica.address()).usersContains(RequestBuilder.Cluster.UserManager.containsReq(name))
+            return this._client.stub(replica.address).usersContains(RequestBuilder.Cluster.UserManager.containsReq(name))
         })
         return failsafeTask.runPrimaryReplica();
     }
 
     create(name: string, password: string): Promise<void> {
         const failsafeTask = new UserManagerFailsafeTask(this._client, (replica: Database.Replica) => {
-            return this._client.stub(replica.address()).userCreate(RequestBuilder.Cluster.UserManager.createReq(name, password))
+            return this._client.stub(replica.address).userCreate(RequestBuilder.Cluster.UserManager.createReq(name, password))
         })
         return failsafeTask.runPrimaryReplica();
     }
@@ -66,7 +66,6 @@ export class ClusterUserManager implements UserManager {
         if (await this.contains(name)) return new ClusterUser(this._client, name);
         else throw new TypeDBClientError(CLUSTER_USER_DOES_NOT_EXIST.message(name));
     }
-
 }
 
 class UserManagerFailsafeTask<T> extends FailsafeTask<T> {
@@ -81,5 +80,4 @@ class UserManagerFailsafeTask<T> extends FailsafeTask<T> {
     run(replica: Database.Replica): Promise<T> {
         return this._task(replica);
     }
-
 }

--- a/connection/core/CoreClient.ts
+++ b/connection/core/CoreClient.ts
@@ -19,7 +19,6 @@
  * under the License.
  */
 
-
 import { TypeDBClientImpl } from "../TypeDBClientImpl";
 import { CoreStubFactory } from "./CoreStubFactory";
 
@@ -28,5 +27,4 @@ export class CoreClient extends TypeDBClientImpl {
     constructor(address: string) {
         super(address, new CoreStubFactory());
     }
-
 }

--- a/connection/core/CoreStub.ts
+++ b/connection/core/CoreStub.ts
@@ -28,7 +28,6 @@ export class CoreStub extends TypeDBStub {
     constructor(stub: TypeDBClient) {
         super(stub);
     }
-
 }
 
 export namespace CoreStub {
@@ -38,5 +37,4 @@ export namespace CoreStub {
             new TypeDBClient(address, ChannelCredentials.createInsecure()),
         );
     }
-
 }

--- a/connection/core/CoreStubFactory.ts
+++ b/connection/core/CoreStubFactory.ts
@@ -28,5 +28,4 @@ export class CoreStubFactory extends TypeDBStubFactory {
     newTypeDBStub(address: string): TypeDBStub {
         return CoreStub.create(address);
     }
-
 }

--- a/logic/ExplanationImpl.ts
+++ b/logic/ExplanationImpl.ts
@@ -28,10 +28,10 @@ import { RuleImpl } from "./RuleImpl";
 
 export class ExplanationImpl implements Explanation {
 
-    private _rule: Rule;
-    private _condition: ConceptMap;
-    private _conclusion: ConceptMap;
-    private _variableMapping: Map<string, Set<string>>;
+    private readonly _rule: Rule;
+    private readonly _condition: ConceptMap;
+    private readonly _conclusion: ConceptMap;
+    private readonly _variableMapping: Map<string, Set<string>>;
 
     constructor(rule: Rule, condition: ConceptMap, conclusion: ConceptMap, variableMapping: Map<string, Set<string>>) {
         this._rule = rule;
@@ -40,22 +40,21 @@ export class ExplanationImpl implements Explanation {
         this._variableMapping = variableMapping;
     }
 
-    rule(): Rule {
+    get rule(): Rule {
         return this._rule;
     }
 
-    conclusion(): ConceptMap {
+    get conclusion(): ConceptMap {
         return this._conclusion;
     }
 
-    condition(): ConceptMap {
+    get condition(): ConceptMap {
         return this._condition;
     }
 
-    variableMapping(): Map<string, Set<string>> {
+    get variableMapping(): Map<string, Set<string>> {
         return this._variableMapping;
     }
-
 }
 
 export namespace ExplanationImpl {

--- a/logic/LogicManagerImpl.ts
+++ b/logic/LogicManagerImpl.ts
@@ -69,5 +69,4 @@ export class LogicManagerImpl implements LogicManager {
     private stream(request: Transaction.Req) {
         return this._transaction.rpcStream(request).map((res) => res.getLogicManagerResPart());
     }
-
 }

--- a/logic/RuleImpl.ts
+++ b/logic/RuleImpl.ts
@@ -39,18 +39,18 @@ export class RuleImpl implements Rule {
     }
 
     asRemote(transaction: TypeDBTransaction): RemoteRule {
-        return new RemoteRuleImpl((transaction as TypeDBTransaction.Extended), this._label, this._when, this._then);
+        return new RuleImpl.Remote((transaction as TypeDBTransaction.Extended), this._label, this._when, this._then);
     }
 
-    getLabel(): string {
+    get label(): string {
         return this._label;
     }
 
-    getWhen(): string {
+    get when(): string {
         return this._when;
     }
 
-    getThen(): string {
+    get then(): string {
         return this._then;
     }
 
@@ -61,44 +61,41 @@ export class RuleImpl implements Rule {
     toString() {
         return "Rule[" + this._label + "]";
     }
-
-}
-
-export class RemoteRuleImpl extends RuleImpl implements RemoteRule {
-    private _transaction: TypeDBTransaction.Extended;
-
-    constructor(transaction: TypeDBTransaction.Extended, label: string, when: string, then: string) {
-        super(label, when, then);
-        this._transaction = transaction;
-    }
-
-    async delete(): Promise<void> {
-        await this._transaction.rpcExecute(deleteReq(this._label));
-    }
-
-    async isDeleted(): Promise<boolean> {
-        return !(await this._transaction.logic().getRule(this._label));
-    }
-
-    async setLabel(label: string): Promise<void> {
-        await this._transaction.rpcExecute(setLabelReq(this._label, label));
-        this._label = label;
-    }
-
-    isRemote(): boolean {
-        return true;
-    }
-
-    toString() {
-        return "RemoteRule[" + this._label + "]";
-    }
-
 }
 
 export namespace RuleImpl {
 
+    export class Remote extends RuleImpl implements RemoteRule {
+        private _transaction: TypeDBTransaction.Extended;
+
+        constructor(transaction: TypeDBTransaction.Extended, label: string, when: string, then: string) {
+            super(label, when, then);
+            this._transaction = transaction;
+        }
+
+        async delete(): Promise<void> {
+            await this._transaction.rpcExecute(deleteReq(this._label));
+        }
+
+        async isDeleted(): Promise<boolean> {
+            return !(await this._transaction.logic.getRule(this._label));
+        }
+
+        async setLabel(label: string): Promise<void> {
+            await this._transaction.rpcExecute(setLabelReq(this._label, label));
+            this._label = label;
+        }
+
+        isRemote(): boolean {
+            return true;
+        }
+
+        toString() {
+            return "Rule[" + this._label + "]";
+        }
+    }
+
     export function of(ruleProto: RuleProto) {
         return new RuleImpl(ruleProto.getLabel(), ruleProto.getWhen(), ruleProto.getThen());
     }
-
 }

--- a/query/QueryManagerImpl.ts
+++ b/query/QueryManagerImpl.ts
@@ -117,7 +117,7 @@ export class QueryManagerImpl implements QueryManager {
 
     explain(explainable: ConceptMap.Explainable, options?: TypeDBOptions): Stream<Explanation> {
         if (!options) options = TypeDBOptions.core();
-        const request = RequestBuilder.QueryManager.explainReq(explainable.id(), options.proto());
+        const request = RequestBuilder.QueryManager.explainReq(explainable.id, options.proto());
         return this.stream(request)
             .flatMap((resPart) => Stream.array(resPart.getExplainResPart().getExplanationsList()))
             .map((explanationProto) => ExplanationImpl.of(explanationProto));

--- a/stream/BidirectionalStream.ts
+++ b/stream/BidirectionalStream.ts
@@ -33,7 +33,6 @@ import MISSING_RESPONSE = ErrorMessage.Client.MISSING_RESPONSE;
 import UNKNOWN_REQUEST_ID = ErrorMessage.Client.UNKNOWN_REQUEST_ID;
 import ResponseQueue = ResponseCollector.ResponseQueue;
 
-
 export class BidirectionalStream {
 
     private readonly _requestTransmitter: RequestTransmitter;

--- a/stream/RequestTransmitter.ts
+++ b/stream/RequestTransmitter.ts
@@ -19,7 +19,6 @@
  * under the License.
  */
 
-
 import { ClientDuplexStream } from "@grpc/grpc-js";
 import { Transaction as TransactionProto } from "typedb-protocol/common/transaction_pb";
 import { RequestBuilder } from "../common/rpc/RequestBuilder";
@@ -41,17 +40,17 @@ export class BatchDispatcher {
         this._isRunning = false;
     }
 
-    public dispatch(req: TransactionProto.Req): void {
+    dispatch(req: TransactionProto.Req): void {
         this._bufferedRequests.push(req);
         this.sendScheduledBatch();
     }
 
-    public dispatchNow(req: TransactionProto.Req): void {
+    dispatchNow(req: TransactionProto.Req): void {
         this._bufferedRequests.push(req);
         this.sendNow();
     }
 
-    public close(): void {
+    close(): void {
         this._transmitter._dispatchers.delete(this);
         this._transactionStream.end();
     }
@@ -79,7 +78,6 @@ export class BatchDispatcher {
             }
         }, wait);
     }
-
 }
 
 export class RequestTransmitter {
@@ -92,17 +90,16 @@ export class RequestTransmitter {
         this._isOpen = true;
     }
 
-    public close(): void {
+    close(): void {
         if (this._isOpen) {
             this._isOpen = false;
             this._dispatchers.forEach(dispatcher => dispatcher.close());
         }
     }
 
-    public dispatcher(transactionStream: ClientDuplexStream<TransactionProto.Client, TransactionProto.Server>): BatchDispatcher {
+    dispatcher(transactionStream: ClientDuplexStream<TransactionProto.Client, TransactionProto.Server>): BatchDispatcher {
         const dispatcher = new BatchDispatcher(this, transactionStream);
         this._dispatchers.add(dispatcher);
         return dispatcher;
     }
-
 }

--- a/stream/ResponseCollector.ts
+++ b/stream/ResponseCollector.ts
@@ -62,10 +62,10 @@ export namespace ResponseCollector {
 
         async take(): Promise<T> {
             const element = await this._queue.take();
-            if (element.isResponse()) return (element as Response<T>).value();
+            if (element.isResponse()) return (element as Response<T>).value;
             else {
                 if ((element as Done).hasError()) {
-                    throw new TypeDBClientError((element as Done).error());
+                    throw new TypeDBClientError((element as Done).error);
                 } else {
                     throw new TypeDBClientError(TRANSACTION_CLOSED);
                 }
@@ -103,7 +103,7 @@ export namespace ResponseCollector {
             this._value = value;
         }
 
-        value(): R {
+        get value(): R {
             return this._value;
         }
 
@@ -124,7 +124,7 @@ export namespace ResponseCollector {
             return this._error != null;
         }
 
-        error(): Error | string {
+        get error(): Error | string {
             return this._error;
         }
 

--- a/stream/ResponsePartIterator.ts
+++ b/stream/ResponsePartIterator.ts
@@ -19,7 +19,6 @@
  * under the License.
  */
 
-
 import { Transaction } from "typedb-protocol/common/transaction_pb";
 import { ErrorMessage } from "../common/errors/ErrorMessage";
 import { TypeDBClientError } from "../common/errors/TypeDBClientError";
@@ -29,7 +28,6 @@ import { ResponseCollector } from "./ResponseCollector";
 import MISSING_RESPONSE = ErrorMessage.Client.MISSING_RESPONSE;
 import UNKNOWN_STREAM_STATE = ErrorMessage.Client.UNKNOWN_STREAM_STATE;
 import ResCase = Transaction.ResPart.ResCase;
-
 
 export class ResponsePartIterator implements AsyncIterable<Transaction.ResPart> {
 
@@ -71,5 +69,4 @@ export class ResponsePartIterator implements AsyncIterable<Transaction.ResPart> 
                 return res;
         }
     }
-
 }

--- a/test/behaviour/concept/thing/ThingSteps.ts
+++ b/test/behaviour/concept/thing/ThingSteps.ts
@@ -45,7 +45,7 @@ When("entity/attribute/relation {var} is deleted: {bool}", async (thingName: str
 
 When("{root_label} {var} has type: {type_label}", async (rootLabel: RootLabel, thingName: string, label: string) => {
     const desiredType = await getThingType(rootLabel, label);
-    assert(get(thingName).getType().equals(desiredType));
+    assert(get(thingName).type.equals(desiredType));
 });
 
 When("delete entity:/attribute:/relation: {var}", async (thingName: string) => {
@@ -91,7 +91,7 @@ When("entity/attribute/relation {var} get attributes do not contain: {var}", asy
 });
 
 When("entity/attribute/relation {var} get attributes\\({type_label}) contain: {var}", async (thingName: string, typeLabel: string, attributeName: string) => {
-    const type = await tx().concepts().getAttributeType(typeLabel)
+    const type = await tx().concepts.getAttributeType(typeLabel)
     for await (const attribute of get(thingName).asRemote(tx()).getHas([type])) {
         if (attribute.equals(get(attributeName))) return;
     }
@@ -99,7 +99,7 @@ When("entity/attribute/relation {var} get attributes\\({type_label}) contain: {v
 });
 
 When("entity/attribute/relation {var} get attributes\\({type_label}) as\\(boolean) contain: {var}", async (thingName: string, typeLabel: string, attributeName: string) => {
-    const type = (await tx().concepts().getAttributeType(typeLabel)).asBoolean();
+    const type = (await tx().concepts.getAttributeType(typeLabel)).asBoolean();
     for await (const attribute of get(thingName).asRemote(tx()).getHas(type)) {
         if (attribute.equals(get(attributeName))) return;
     }
@@ -107,7 +107,7 @@ When("entity/attribute/relation {var} get attributes\\({type_label}) as\\(boolea
 });
 
 When("entity/attribute/relation {var} get attributes\\({type_label}) as\\(long) contain: {var}", async (thingName: string, typeLabel: string, attributeName: string) => {
-    const type = (await tx().concepts().getAttributeType(typeLabel)).asLong();
+    const type = (await tx().concepts.getAttributeType(typeLabel)).asLong();
     for await (const attribute of get(thingName).asRemote(tx()).getHas(type)) {
         if (attribute.equals(get(attributeName))) return;
     }
@@ -115,7 +115,7 @@ When("entity/attribute/relation {var} get attributes\\({type_label}) as\\(long) 
 });
 
 When("entity/attribute/relation {var} get attributes\\({type_label}) as\\(double) contain: {var}", async (thingName: string, typeLabel: string, attributeName: string) => {
-    const type = (await tx().concepts().getAttributeType(typeLabel)).asDouble();
+    const type = (await tx().concepts.getAttributeType(typeLabel)).asDouble();
     for await (const attribute of get(thingName).asRemote(tx()).getHas(type)) {
         if (attribute.equals(get(attributeName))) return;
     }
@@ -123,7 +123,7 @@ When("entity/attribute/relation {var} get attributes\\({type_label}) as\\(double
 });
 
 When("entity/attribute/relation {var} get attributes\\({type_label}) as\\(string) contain: {var}", async (thingName: string, typeLabel: string, attributeName: string) => {
-    const type = (await tx().concepts().getAttributeType(typeLabel)).asString();
+    const type = (await tx().concepts.getAttributeType(typeLabel)).asString();
     for await (const attribute of get(thingName).asRemote(tx()).getHas(type)) {
         if (attribute.equals(get(attributeName))) return;
     }
@@ -131,7 +131,7 @@ When("entity/attribute/relation {var} get attributes\\({type_label}) as\\(string
 });
 
 When("entity/attribute/relation {var} get attributes\\({type_label}) as\\(datetime) contain: {var}", async (thingName: string, typeLabel: string, attributeName: string) => {
-    const type = (await tx().concepts().getAttributeType(typeLabel)).asDateTime();
+    const type = (await tx().concepts.getAttributeType(typeLabel)).asDateTime();
     for await (const attribute of get(thingName).asRemote(tx()).getHas(type)) {
         if (attribute.equals(get(attributeName))) return;
     }
@@ -139,49 +139,49 @@ When("entity/attribute/relation {var} get attributes\\({type_label}) as\\(dateti
 });
 
 When("entity/attribute/relation {var} get attributes\\({type_label}) do not contain: {var}", async (thingName: string, typeLabel: string, attributeName: string) => {
-    const type = await tx().concepts().getAttributeType(typeLabel)
+    const type = await tx().concepts.getAttributeType(typeLabel)
     for await (const attribute of get(thingName).asRemote(tx()).getHas([type])) {
         if (attribute.equals(get(attributeName))) assert.fail();
     }
 });
 
 When("entity/attribute/relation {var} get attributes\\({type_label}) as\\(boolean) do not contain: {var}", async (thingName: string, typeLabel: string, attributeName: string) => {
-    const type = (await tx().concepts().getAttributeType(typeLabel)).asBoolean();
+    const type = (await tx().concepts.getAttributeType(typeLabel)).asBoolean();
     for await (const attribute of get(thingName).asRemote(tx()).getHas(type)) {
         if (attribute.equals(get(attributeName))) assert.fail();
     }
 });
 
 When("entity/attribute/relation {var} get attributes\\({type_label}) as\\(long) do not contain: {var}", async (thingName: string, typeLabel: string, attributeName: string) => {
-    const type = (await tx().concepts().getAttributeType(typeLabel)).asLong();
+    const type = (await tx().concepts.getAttributeType(typeLabel)).asLong();
     for await (const attribute of get(thingName).asRemote(tx()).getHas(type)) {
         if (attribute.equals(get(attributeName))) assert.fail();
     }
 });
 
 When("entity/attribute/relation {var} get attributes\\({type_label}) as\\(double) do not contain: {var}", async (thingName: string, typeLabel: string, attributeName: string) => {
-    const type = (await tx().concepts().getAttributeType(typeLabel)).asDouble();
+    const type = (await tx().concepts.getAttributeType(typeLabel)).asDouble();
     for await (const attribute of get(thingName).asRemote(tx()).getHas(type)) {
         if (attribute.equals(get(attributeName))) assert.fail();
     }
 });
 
 When("entity/attribute/relation {var} get attributes\\({type_label}) as\\(string) do not contain: {var}", async (thingName: string, typeLabel: string, attributeName: string) => {
-    const type = (await tx().concepts().getAttributeType(typeLabel)).asString();
+    const type = (await tx().concepts.getAttributeType(typeLabel)).asString();
     for await (const attribute of get(thingName).asRemote(tx()).getHas(type)) {
         if (attribute.equals(get(attributeName))) assert.fail();
     }
 });
 
 When("entity/attribute/relation {var} get attributes\\({type_label}) as\\(datetime) do not contain: {var}", async (thingName: string, typeLabel: string, attributeName: string) => {
-    const type = (await tx().concepts().getAttributeType(typeLabel)).asDateTime();
+    const type = (await tx().concepts.getAttributeType(typeLabel)).asDateTime();
     for await (const attribute of get(thingName).asRemote(tx()).getHas(type)) {
         if (attribute.equals(get(attributeName))) assert.fail();
     }
 });
 
 When("entity/attribute/relation {var} get relations\\({scoped_label}) contain: {var}", async (thingName: string, scopedLabel: ScopedLabel, relationName: string) => {
-    const roleType = await (await tx().concepts().getRelationType(scopedLabel.scope())).asRemote(tx()).getRelates(scopedLabel.role())
+    const roleType = await (await tx().concepts.getRelationType(scopedLabel.scope)).asRemote(tx()).getRelates(scopedLabel.role)
     for await (const relation of get(thingName).asRemote(tx()).getRelations([roleType])) {
         if (relation.equals(get(relationName))) return;
     }
@@ -196,7 +196,7 @@ When("entity/attribute/relation {var} get relations contain: {var}", async (thin
 });
 
 When("entity/attribute/relation {var} get relations\\({scoped_label}) do not contain: {var}", async (thingName: string, scopedLabel: ScopedLabel, relationName: string) => {
-    const roleType = await (await tx().concepts().getRelationType(scopedLabel.scope())).asRemote(tx()).getRelates(scopedLabel.role())
+    const roleType = await (await tx().concepts.getRelationType(scopedLabel.scope)).asRemote(tx()).getRelates(scopedLabel.role)
     for await (const relation of get(thingName).asRemote(tx()).getRelations([roleType])) {
         if (relation.equals(get(relationName))) assert.fail();
     }
@@ -210,16 +210,16 @@ When("entity/attribute/relation {var} get relations do not contain: {var}", asyn
 });
 
 When("root\\(thing) get instances count: {int}", async (count: number) => {
-    assert.strictEqual((await (await tx().concepts().getRootThingType()).asRemote(tx()).getInstances().collect()).length, count);
+    assert.strictEqual((await (await tx().concepts.getRootThingType()).asRemote(tx()).getInstances().collect()).length, count);
 });
 
 When("root\\(thing) get instances contain: {var}", async (variableName: string) => {
-    for await (const instance of (await tx().concepts().getRootThingType()).asRemote(tx()).getInstances()) {
+    for await (const instance of (await tx().concepts.getRootThingType()).asRemote(tx()).getInstances()) {
         if (instance.equals(get(variableName))) return;
     }
     assert.fail();
 });
 
 When("root\\(thing) get instances is empty", async () => {
-    assert.strictEqual((await (await tx().concepts().getRootThingType()).asRemote(tx()).getInstances().collect()).length, 0);
+    assert.strictEqual((await (await tx().concepts.getRootThingType()).asRemote(tx()).getInstances().collect()).length, 0);
 });

--- a/test/behaviour/concept/thing/attribute/AttributeSteps.ts
+++ b/test/behaviour/concept/thing/attribute/AttributeSteps.ts
@@ -28,7 +28,7 @@ import assert = require("assert");
 import ValueType = AttributeType.ValueType;
 
 When("attribute\\({type_label}) get instances contain: {var}", async (typeLabel: string, var0: string) => {
-    assert(await (await tx().concepts().getAttributeType(typeLabel)).asRemote(tx()).getInstances().some(x => x.equals(get(var0))));
+    assert(await (await tx().concepts.getAttributeType(typeLabel)).asRemote(tx()).getInstances().some(x => x.equals(get(var0))));
 });
 
 When("attribute {var} get owners contain: {var}", async (var1: string, var2: string) => {
@@ -40,85 +40,85 @@ When("attribute {var} get owners do not contain: {var}", async (var1: string, va
 });
 
 When("attribute {var} has value type: {value_type}", async (var0: string, valueType: ValueType) => {
-    assert.strictEqual(valueType, (get(var0) as Attribute).getType().getValueType());
+    assert.strictEqual(valueType, (get(var0) as Attribute).type.valueType);
 });
 
 When("{var} = attribute\\({type_label}) as\\(boolean) put: {bool}", async (var0: string, typeLabel: string, value: boolean) => {
-    put(var0, await ((await tx().concepts().getAttributeType(typeLabel)) as AttributeType.Boolean).asRemote(tx()).put(value))
+    put(var0, await ((await tx().concepts.getAttributeType(typeLabel)) as AttributeType.Boolean).asRemote(tx()).put(value))
 });
 
 When("attribute\\({type_label}) as\\(boolean) put: {bool}; throws exception", async (typeLabel: string, value: boolean) => {
-    await assertThrows(async () => await ((await tx().concepts().getAttributeType(typeLabel)) as AttributeType.Boolean).asRemote(tx()).put(value))
+    await assertThrows(async () => await ((await tx().concepts.getAttributeType(typeLabel)) as AttributeType.Boolean).asRemote(tx()).put(value))
 });
 
 When("{var} = attribute\\({type_label}) as\\(long) put: {int}", async (var0: string, typeLabel: string, value: number) => {
-    put(var0, await ((await tx().concepts().getAttributeType(typeLabel)) as AttributeType.Long).asRemote(tx()).put(value))
+    put(var0, await ((await tx().concepts.getAttributeType(typeLabel)) as AttributeType.Long).asRemote(tx()).put(value))
 });
 
 When("attribute\\({type_label}) as\\(long) put: {int}; throws exception", async (typeLabel: string, value: number) => {
-    await assertThrows(async () => await ((await tx().concepts().getAttributeType(typeLabel)) as AttributeType.Long).asRemote(tx()).put(value))
+    await assertThrows(async () => await ((await tx().concepts.getAttributeType(typeLabel)) as AttributeType.Long).asRemote(tx()).put(value))
 });
 
 When("{var} = attribute\\({type_label}) as\\(double) put: {float}", async (var0: string, typeLabel: string, value: number) => {
-    put(var0, await ((await tx().concepts().getAttributeType(typeLabel)) as AttributeType.Double).asRemote(tx()).put(value))
+    put(var0, await ((await tx().concepts.getAttributeType(typeLabel)) as AttributeType.Double).asRemote(tx()).put(value))
 });
 
 When("attribute\\({type_label}) as\\(double) put: {float}; throws exception", async (typeLabel: string, value: number) => {
-    await assertThrows(async () => await ((await tx().concepts().getAttributeType(typeLabel)) as AttributeType.Double).asRemote(tx()).put(value))
+    await assertThrows(async () => await ((await tx().concepts.getAttributeType(typeLabel)) as AttributeType.Double).asRemote(tx()).put(value))
 });
 
 When("{var} = attribute\\({type_label}) as\\(string) put: {word}", async (var0: string, typeLabel: string, value: string) => {
-    put(var0, await ((await tx().concepts().getAttributeType(typeLabel)) as AttributeType.String).asRemote(tx()).put(value))
+    put(var0, await ((await tx().concepts.getAttributeType(typeLabel)) as AttributeType.String).asRemote(tx()).put(value))
 });
 
 When("attribute\\({type_label}) as\\(string) put: {word}; throws exception", async (typeLabel: string, value: string) => {
-    await assertThrows(async () => await ((await tx().concepts().getAttributeType(typeLabel)) as AttributeType.String).asRemote(tx()).put(value))
+    await assertThrows(async () => await ((await tx().concepts.getAttributeType(typeLabel)) as AttributeType.String).asRemote(tx()).put(value))
 });
 
 When("{var} = attribute\\({type_label}) as\\(datetime) put: {datetime}", async (var0: string, typeLabel: string, value: Date) => {
-    put(var0, await ((await tx().concepts().getAttributeType(typeLabel)) as AttributeType.DateTime).asRemote(tx()).put(value))
+    put(var0, await ((await tx().concepts.getAttributeType(typeLabel)) as AttributeType.DateTime).asRemote(tx()).put(value))
 });
 
 When("attribute\\({type_label}) as\\(datetime) put: {datetime}; throws exception", async (typeLabel: string, value: Date) => {
-    await assertThrows(async () => await ((await tx().concepts().getAttributeType(typeLabel)) as AttributeType.DateTime).asRemote(tx()).put(value))
+    await assertThrows(async () => await ((await tx().concepts.getAttributeType(typeLabel)) as AttributeType.DateTime).asRemote(tx()).put(value))
 });
 
 When("{var} = attribute\\({type_label}) as\\(boolean) get: {bool}", async (var0: string, typeLabel: string, value: boolean) => {
-    put(var0, await ((await tx().concepts().getAttributeType(typeLabel)) as AttributeType.Boolean).asRemote(tx()).get(value))
+    put(var0, await ((await tx().concepts.getAttributeType(typeLabel)) as AttributeType.Boolean).asRemote(tx()).get(value))
 });
 
 When("{var} = attribute\\({type_label}) as\\(long) get: {int}", async (var0: string, typeLabel: string, value: number) => {
-    put(var0, await ((await tx().concepts().getAttributeType(typeLabel)) as AttributeType.Long).asRemote(tx()).get(value))
+    put(var0, await ((await tx().concepts.getAttributeType(typeLabel)) as AttributeType.Long).asRemote(tx()).get(value))
 });
 
 When("{var} = attribute\\({type_label}) as\\(double) get: {float}", async (var0: string, typeLabel: string, value: number) => {
-    put(var0, await ((await tx().concepts().getAttributeType(typeLabel)) as AttributeType.Double).asRemote(tx()).get(value))
+    put(var0, await ((await tx().concepts.getAttributeType(typeLabel)) as AttributeType.Double).asRemote(tx()).get(value))
 });
 
 When("{var} = attribute\\({type_label}) as\\(string) get: {word}", async (var0: string, typeLabel: string, value: string) => {
-    put(var0, await ((await tx().concepts().getAttributeType(typeLabel)) as AttributeType.String).asRemote(tx()).get(value))
+    put(var0, await ((await tx().concepts.getAttributeType(typeLabel)) as AttributeType.String).asRemote(tx()).get(value))
 });
 
 When("{var} = attribute\\({type_label}) as\\(datetime) get: {datetime}", async (var0: string, typeLabel: string, value: Date) => {
-    put(var0, await ((await tx().concepts().getAttributeType(typeLabel)) as AttributeType.DateTime).asRemote(tx()).get(value))
+    put(var0, await ((await tx().concepts.getAttributeType(typeLabel)) as AttributeType.DateTime).asRemote(tx()).get(value))
 });
 
 When("attribute {var} has boolean value: {bool}", async (var0: string, value: boolean) => {
-    assert.strictEqual(value, (get(var0) as Attribute.Boolean).getValue())
+    assert.strictEqual(value, (get(var0) as Attribute.Boolean).value)
 });
 
 When("attribute {var} has long value: {int}", async (var0: string, value: number) => {
-    assert.strictEqual(value, (get(var0) as Attribute.Long).getValue())
+    assert.strictEqual(value, (get(var0) as Attribute.Long).value)
 });
 
 When("attribute {var} has double value: {float}", async (var0: string, value: number) => {
-    assert.strictEqual(value, (get(var0) as Attribute.Double).getValue())
+    assert.strictEqual(value, (get(var0) as Attribute.Double).value)
 });
 
 When("attribute {var} has string value: {word}", async (var0: string, value: string) => {
-    assert.strictEqual(value, (get(var0) as Attribute.String).getValue())
+    assert.strictEqual(value, (get(var0) as Attribute.String).value)
 });
 
 When("attribute {var} has datetime value: {datetime}", async (var0: string, value: Date) => {
-    assert.strictEqual(value.getTime(), (get(var0) as Attribute.DateTime).getValue().getTime())
+    assert.strictEqual(value.getTime(), (get(var0) as Attribute.DateTime).value.getTime())
 });

--- a/test/behaviour/concept/thing/entity/EntitySteps.ts
+++ b/test/behaviour/concept/thing/entity/EntitySteps.ts
@@ -29,17 +29,17 @@ import { get, put } from "../ThingSteps";
 import assert = require("assert");
 
 When("{var} = entity\\({type_label}) create new instance", async (var0: string, typeLabel: string) => {
-    put(var0, await (await tx().concepts().getEntityType(typeLabel)).asRemote(tx()).create());
+    put(var0, await (await tx().concepts.getEntityType(typeLabel)).asRemote(tx()).create());
 });
 
 When("entity\\({type_label}) create new instance; throws exception", async (typeLabel: string) => {
-    await assertThrows(async () => await (await tx().concepts().getEntityType(typeLabel)).asRemote(tx()).create());
+    await assertThrows(async () => await (await tx().concepts.getEntityType(typeLabel)).asRemote(tx()).create());
 });
 
 When("{var} = entity\\({type_label}) create new instance with key\\({type_label}): {bool}",
     async (thingName: string, thingTypeLabel: string, keyTypeLabel: string, value: boolean) => {
-        const key = await ((await tx().concepts().getAttributeType(keyTypeLabel)) as AttributeType.Boolean).asRemote(tx()).put(value);
-        const entity = await (await tx().concepts().getEntityType(thingTypeLabel)).asRemote(tx()).create();
+        const key = await ((await tx().concepts.getAttributeType(keyTypeLabel)) as AttributeType.Boolean).asRemote(tx()).put(value);
+        const entity = await (await tx().concepts.getEntityType(thingTypeLabel)).asRemote(tx()).create();
         await entity.asRemote(tx()).setHas(key)
         put(thingName, entity);
     }
@@ -47,8 +47,8 @@ When("{var} = entity\\({type_label}) create new instance with key\\({type_label}
 
 When("{var} = entity\\({type_label}) create new instance with key\\({type_label}): {int}",
     async (thingName: string, thingTypeLabel: string, keyTypeLabel: string, value: number) => {
-        const key = await ((await tx().concepts().getAttributeType(keyTypeLabel)) as AttributeType.Long).asRemote(tx()).put(value);
-        const entity = await (await tx().concepts().getEntityType(thingTypeLabel)).asRemote(tx()).create();
+        const key = await ((await tx().concepts.getAttributeType(keyTypeLabel)) as AttributeType.Long).asRemote(tx()).put(value);
+        const entity = await (await tx().concepts.getEntityType(thingTypeLabel)).asRemote(tx()).create();
         await entity.asRemote(tx()).setHas(key)
         put(thingName, entity);
     }
@@ -56,8 +56,8 @@ When("{var} = entity\\({type_label}) create new instance with key\\({type_label}
 
 When("{var} = entity\\({type_label}) create new instance with key\\({type_label}): {word}",
     async (thingName: string, thingTypeLabel: string, keyTypeLabel: string, value: string) => {
-        const key = await ((await tx().concepts().getAttributeType(keyTypeLabel)) as AttributeType.String).asRemote(tx()).put(value);
-        const entity = await (await tx().concepts().getEntityType(thingTypeLabel)).asRemote(tx()).create();
+        const key = await ((await tx().concepts.getAttributeType(keyTypeLabel)) as AttributeType.String).asRemote(tx()).put(value);
+        const entity = await (await tx().concepts.getEntityType(thingTypeLabel)).asRemote(tx()).create();
         await entity.asRemote(tx()).setHas(key)
         put(thingName, entity);
     }
@@ -65,8 +65,8 @@ When("{var} = entity\\({type_label}) create new instance with key\\({type_label}
 
 When("{var} = entity\\({type_label}) create new instance with key\\({type_label}): {datetime}",
     async (thingName: string, thingTypeLabel: string, keyTypeLabel: string, value: Date) => {
-        const key = await ((await tx().concepts().getAttributeType(keyTypeLabel)) as AttributeType.DateTime).asRemote(tx()).put(value);
-        const entity = await (await tx().concepts().getEntityType(thingTypeLabel)).asRemote(tx()).create();
+        const key = await ((await tx().concepts.getAttributeType(keyTypeLabel)) as AttributeType.DateTime).asRemote(tx()).put(value);
+        const entity = await (await tx().concepts.getEntityType(thingTypeLabel)).asRemote(tx()).create();
         await entity.asRemote(tx()).setHas(key)
         put(thingName, entity);
     }
@@ -74,9 +74,9 @@ When("{var} = entity\\({type_label}) create new instance with key\\({type_label}
 
 When("{var} = entity\\({type_label}) get instance with key\\({type_label}): {bool}",
     async (thingName: string, thingTypeLabel: string, keyTypeLabel: string, value: boolean) => {
-        const key = await ((await tx().concepts().getAttributeType(keyTypeLabel)) as AttributeType.Boolean).asRemote(tx()).get(value);
+        const key = await ((await tx().concepts.getAttributeType(keyTypeLabel)) as AttributeType.Boolean).asRemote(tx()).get(value);
         for await (const owner of key.asRemote(tx()).getOwners()) {
-            if (owner.getType().getLabel().scopedName() === thingTypeLabel) {
+            if (owner.type.label.scopedName === thingTypeLabel) {
                 put(thingName, owner);
                 return;
             }
@@ -87,9 +87,9 @@ When("{var} = entity\\({type_label}) get instance with key\\({type_label}): {boo
 
 When("{var} = entity\\({type_label}) get instance with key\\({type_label}): {int}",
     async (thingName: string, thingTypeLabel: string, keyTypeLabel: string, value: number) => {
-        const key = await ((await tx().concepts().getAttributeType(keyTypeLabel)) as AttributeType.Long).asRemote(tx()).get(value);
+        const key = await ((await tx().concepts.getAttributeType(keyTypeLabel)) as AttributeType.Long).asRemote(tx()).get(value);
         for await (const owner of key.asRemote(tx()).getOwners()) {
-            if (owner.getType().getLabel().scopedName() === thingTypeLabel) {
+            if (owner.type.label.scopedName === thingTypeLabel) {
                 put(thingName, owner);
                 return;
             }
@@ -100,9 +100,9 @@ When("{var} = entity\\({type_label}) get instance with key\\({type_label}): {int
 
 When("{var} = entity\\({type_label}) get instance with key\\({type_label}): {word}",
     async (thingName: string, thingTypeLabel: string, keyTypeLabel: string, value: string) => {
-        const key = await ((await tx().concepts().getAttributeType(keyTypeLabel)) as AttributeType.String).asRemote(tx()).get(value);
+        const key = await ((await tx().concepts.getAttributeType(keyTypeLabel)) as AttributeType.String).asRemote(tx()).get(value);
         for await (const owner of key.asRemote(tx()).getOwners()) {
-            if (owner.getType().getLabel().scopedName() === thingTypeLabel) {
+            if (owner.type.label.scopedName === thingTypeLabel) {
                 put(thingName, owner);
                 return;
             }
@@ -113,9 +113,9 @@ When("{var} = entity\\({type_label}) get instance with key\\({type_label}): {wor
 
 When("{var} = entity\\({type_label}) get instance with key\\({type_label}): {datetime}",
     async (thingName: string, thingTypeLabel: string, keyTypeLabel: string, value: Date) => {
-        const key = await ((await tx().concepts().getAttributeType(keyTypeLabel)) as AttributeType.DateTime).asRemote(tx()).get(value);
+        const key = await ((await tx().concepts.getAttributeType(keyTypeLabel)) as AttributeType.DateTime).asRemote(tx()).get(value);
         for await (const owner of key.asRemote(tx()).getOwners()) {
-            if ((await owner.asRemote(tx()).getType()).equals(await tx().concepts().getEntityType(thingTypeLabel))) {
+            if ((await owner.asRemote(tx()).type).equals(await tx().concepts.getEntityType(thingTypeLabel))) {
                 put(thingName, owner);
                 return
             }
@@ -125,12 +125,12 @@ When("{var} = entity\\({type_label}) get instance with key\\({type_label}): {dat
 );
 
 When("entity\\({type_label}) get instances contain: {var}", async (typeLabel: string, variableName: string) => {
-    for await (const instance of (await tx().concepts().getEntityType(typeLabel)).asRemote(tx()).getInstances()) {
+    for await (const instance of (await tx().concepts.getEntityType(typeLabel)).asRemote(tx()).getInstances()) {
         if (instance.equals(get(variableName))) return;
     }
     assert.fail();
 });
 
 When("entity\\({type_label}) get instances is empty", async (typeLabel: string) => {
-    assert.strictEqual((await (await tx().concepts().getEntityType(typeLabel)).asRemote(tx()).getInstances().collect()).length, 0);
+    assert.strictEqual((await (await tx().concepts.getEntityType(typeLabel)).asRemote(tx()).getInstances().collect()).length, 0);
 });

--- a/test/behaviour/concept/thing/relation/RelationSteps.ts
+++ b/test/behaviour/concept/thing/relation/RelationSteps.ts
@@ -29,17 +29,17 @@ import { get, put } from "../ThingSteps";
 import assert = require("assert");
 
 When("{var} = relation\\({type_label}) create new instance", async (var0: string, typeLabel: string) => {
-    put(var0, await (await tx().concepts().getRelationType(typeLabel)).asRemote(tx()).create());
+    put(var0, await (await tx().concepts.getRelationType(typeLabel)).asRemote(tx()).create());
 });
 
 When("relation\\({type_label}) create new instance; throws exception", async (typeLabel: string) => {
-    await assertThrows(async () => await (await tx().concepts().getRelationType(typeLabel)).asRemote(tx()).create());
+    await assertThrows(async () => await (await tx().concepts.getRelationType(typeLabel)).asRemote(tx()).create());
 });
 
 When("{var} = relation\\({type_label}) create new instance with key\\({type_label}): {bool}",
     async (thingName: string, thingTypeLabel: string, keyTypeLabel: string, value: boolean) => {
-        const key = await ((await tx().concepts().getAttributeType(keyTypeLabel)) as AttributeType.Boolean).asRemote(tx()).put(value);
-        const relation = await (await tx().concepts().getRelationType(thingTypeLabel)).asRemote(tx()).create();
+        const key = await ((await tx().concepts.getAttributeType(keyTypeLabel)) as AttributeType.Boolean).asRemote(tx()).put(value);
+        const relation = await (await tx().concepts.getRelationType(thingTypeLabel)).asRemote(tx()).create();
         await relation.asRemote(tx()).setHas(key)
         put(thingName, relation);
     }
@@ -47,8 +47,8 @@ When("{var} = relation\\({type_label}) create new instance with key\\({type_labe
 
 When("{var} = relation\\({type_label}) create new instance with key\\({type_label}): {int}",
     async (thingName: string, thingTypeLabel: string, keyTypeLabel: string, value: number) => {
-        const key = await ((await tx().concepts().getAttributeType(keyTypeLabel)) as AttributeType.Long).asRemote(tx()).put(value);
-        const relation = await (await tx().concepts().getRelationType(thingTypeLabel)).asRemote(tx()).create();
+        const key = await ((await tx().concepts.getAttributeType(keyTypeLabel)) as AttributeType.Long).asRemote(tx()).put(value);
+        const relation = await (await tx().concepts.getRelationType(thingTypeLabel)).asRemote(tx()).create();
         await relation.asRemote(tx()).setHas(key)
         put(thingName, relation);
     }
@@ -56,8 +56,8 @@ When("{var} = relation\\({type_label}) create new instance with key\\({type_labe
 
 When("{var} = relation\\({type_label}) create new instance with key\\({type_label}): {word}",
     async (thingName: string, thingTypeLabel: string, keyTypeLabel: string, value: string) => {
-        const key = await ((await tx().concepts().getAttributeType(keyTypeLabel)) as AttributeType.String).asRemote(tx()).put(value);
-        const relation = await (await tx().concepts().getRelationType(thingTypeLabel)).asRemote(tx()).create();
+        const key = await ((await tx().concepts.getAttributeType(keyTypeLabel)) as AttributeType.String).asRemote(tx()).put(value);
+        const relation = await (await tx().concepts.getRelationType(thingTypeLabel)).asRemote(tx()).create();
         await relation.asRemote(tx()).setHas(key)
         put(thingName, relation);
     }
@@ -65,8 +65,8 @@ When("{var} = relation\\({type_label}) create new instance with key\\({type_labe
 
 When("{var} = relation\\({type_label}) create new instance with key\\({type_label}): {datetime}",
     async (thingName: string, thingTypeLabel: string, keyTypeLabel: string, value: Date) => {
-        const key = await ((await tx().concepts().getAttributeType(keyTypeLabel)) as AttributeType.DateTime).asRemote(tx()).put(value);
-        const relation = await (await tx().concepts().getRelationType(thingTypeLabel)).asRemote(tx()).create();
+        const key = await ((await tx().concepts.getAttributeType(keyTypeLabel)) as AttributeType.DateTime).asRemote(tx()).put(value);
+        const relation = await (await tx().concepts.getRelationType(thingTypeLabel)).asRemote(tx()).create();
         await relation.asRemote(tx()).setHas(key)
         put(thingName, relation);
     }
@@ -74,9 +74,9 @@ When("{var} = relation\\({type_label}) create new instance with key\\({type_labe
 
 When("{var} = relation\\({type_label}) get instance with key\\({type_label}): {bool}",
     async (thingName: string, thingTypeLabel: string, keyTypeLabel: string, value: boolean) => {
-        const key = await ((await tx().concepts().getAttributeType(keyTypeLabel)) as AttributeType.Boolean).asRemote(tx()).get(value);
+        const key = await ((await tx().concepts.getAttributeType(keyTypeLabel)) as AttributeType.Boolean).asRemote(tx()).get(value);
         for await (const owner of key.asRemote(tx()).getOwners()) {
-            if (owner.getType().getLabel().scopedName() === thingTypeLabel) {
+            if (owner.type.label.scopedName === thingTypeLabel) {
                 put(thingName, owner);
                 return
             }
@@ -87,9 +87,9 @@ When("{var} = relation\\({type_label}) get instance with key\\({type_label}): {b
 
 When("{var} = relation\\({type_label}) get instance with key\\({type_label}): {int}",
     async (thingName: string, thingTypeLabel: string, keyTypeLabel: string, value: number) => {
-        const key = await ((await tx().concepts().getAttributeType(keyTypeLabel)) as AttributeType.Long).asRemote(tx()).get(value);
+        const key = await ((await tx().concepts.getAttributeType(keyTypeLabel)) as AttributeType.Long).asRemote(tx()).get(value);
         for await (const owner of key.asRemote(tx()).getOwners()) {
-            if (owner.getType().getLabel().scopedName() === thingTypeLabel) {
+            if (owner.type.label.scopedName === thingTypeLabel) {
                 put(thingName, owner);
                 return
             }
@@ -100,9 +100,9 @@ When("{var} = relation\\({type_label}) get instance with key\\({type_label}): {i
 
 When("{var} = relation\\({type_label}) get instance with key\\({type_label}): {word}",
     async (thingName: string, thingTypeLabel: string, keyTypeLabel: string, value: string) => {
-        const key = await ((await tx().concepts().getAttributeType(keyTypeLabel)) as AttributeType.String).asRemote(tx()).get(value);
+        const key = await ((await tx().concepts.getAttributeType(keyTypeLabel)) as AttributeType.String).asRemote(tx()).get(value);
         for await (const owner of key.asRemote(tx()).getOwners()) {
-            if (owner.getType().getLabel().scopedName() === thingTypeLabel) {
+            if (owner.type.label.scopedName === thingTypeLabel) {
                 put(thingName, owner);
                 return
             }
@@ -113,9 +113,9 @@ When("{var} = relation\\({type_label}) get instance with key\\({type_label}): {w
 
 When("{var} = relation\\({type_label}) get instance with key\\({type_label}): {datetime}",
     async (thingName: string, thingTypeLabel: string, keyTypeLabel: string, value: Date) => {
-        const key = await ((await tx().concepts().getAttributeType(keyTypeLabel)) as AttributeType.DateTime).asRemote(tx()).get(value);
+        const key = await ((await tx().concepts.getAttributeType(keyTypeLabel)) as AttributeType.DateTime).asRemote(tx()).get(value);
         for await (const owner of key.asRemote(tx()).getOwners()) {
-            if ((await owner.asRemote(tx()).getType()).equals(await tx().concepts().getRelationType(thingTypeLabel))) {
+            if ((await owner.asRemote(tx()).type).equals(await tx().concepts.getRelationType(thingTypeLabel))) {
                 put(thingName, owner);
                 return
             }
@@ -125,25 +125,25 @@ When("{var} = relation\\({type_label}) get instance with key\\({type_label}): {d
 );
 
 When("relation\\({type_label}) get instances contain: {var}", async (typeLabel: string, variableName: string) => {
-    for await (const instance of (await tx().concepts().getRelationType(typeLabel)).asRemote(tx()).getInstances()) {
+    for await (const instance of (await tx().concepts.getRelationType(typeLabel)).asRemote(tx()).getInstances()) {
         if (instance.equals(get(variableName))) return;
     }
     assert.fail();
 });
 
 When("relation\\({type_label}) get instances do not contain: {var}", async (typeLabel: string, variableName: string) => {
-    for await (const instance of (await tx().concepts().getRelationType(typeLabel)).asRemote(tx()).getInstances()) {
+    for await (const instance of (await tx().concepts.getRelationType(typeLabel)).asRemote(tx()).getInstances()) {
         if (instance.equals(get(variableName))) assert.fail();
     }
 });
 
 When("relation\\({type_label}) get instances is empty", async (typeLabel: string) => {
-    assert.strictEqual((await (await tx().concepts().getRelationType(typeLabel)).asRemote(tx()).getInstances().collect()).length, 0);
+    assert.strictEqual((await (await tx().concepts.getRelationType(typeLabel)).asRemote(tx()).getInstances().collect()).length, 0);
 });
 
 When("relation {var} add player for role\\({type_label}): {var}", async (relationName: string, typeLabel: string, playerName: string) => {
     const relation = get(relationName) as Relation;
-    const roleType = await relation.getType().asRemote(tx()).getRelates(typeLabel);
+    const roleType = await relation.type.asRemote(tx()).getRelates(typeLabel);
     const player = get(playerName);
     await relation.asRemote(tx()).addPlayer(roleType, player);
 });
@@ -151,7 +151,7 @@ When("relation {var} add player for role\\({type_label}): {var}", async (relatio
 When("relation {var} add player for role\\({type_label}): {var}; throws exception", async (relationName: string, typeLabel: string, playerName: string) => {
     await assertThrows(async () => {
         const relation = get(relationName) as Relation;
-        const roleType = await relation.getType().asRemote(tx()).getRelates(typeLabel);
+        const roleType = await relation.type.asRemote(tx()).getRelates(typeLabel);
         const player = get(playerName);
         await relation.asRemote(tx()).addPlayer(roleType, player);
     });
@@ -159,7 +159,7 @@ When("relation {var} add player for role\\({type_label}): {var}; throws exceptio
 
 When("relation {var} remove player for role\\({type_label}): {var}", async (relationName: string, typeLabel: string, playerName: string) => {
     const relation = get(relationName) as Relation;
-    const roleType = await relation.getType().asRemote(tx()).getRelates(typeLabel);
+    const roleType = await relation.type.asRemote(tx()).getRelates(typeLabel);
     const player = get(playerName);
     await relation.asRemote(tx()).removePlayer(roleType, player);
 });
@@ -169,7 +169,7 @@ When("relation {var} get players contain:", async (var1: string, players: DataTa
     const playersByRoleType = await relation.asRemote(tx()).getPlayersByRoleType();
     for (const [roleLabel, var2Raw] of players.raw()) {
         const var2 = parseVar(var2Raw);
-        const roleType = Array.from(playersByRoleType.keys()).find(x => x.getLabel().name() == roleLabel);
+        const roleType = Array.from(playersByRoleType.keys()).find(x => x.label.name == roleLabel);
         assert(roleType);
         assert(playersByRoleType.get(roleType).some(x => x.equals(get(var2))));
     }
@@ -180,7 +180,7 @@ When("relation {var} get players do not contain:", async (var1: string, players:
     const playersByRoleType = await relation.asRemote(tx()).getPlayersByRoleType();
     for (const [roleLabel, var2Raw] of players.raw()) {
         const var2 = parseVar(var2Raw);
-        const roleType = Array.from(playersByRoleType.keys()).find(x => x.getLabel().scopedName() == roleLabel);
+        const roleType = Array.from(playersByRoleType.keys()).find(x => x.label.scopedName == roleLabel);
         assert(!playersByRoleType.get(roleType)?.some(x => x.equals(get(var2))));
     }
 });
@@ -194,11 +194,11 @@ When("relation {var} get players do not contain: {var}", async (var1: string, va
 });
 
 When("relation {var} get players for role\\({type_label}) contain: {var}", async (var1: string, roleLabel: string, var2: string) => {
-    const roleType = await (get(var1) as Relation).getType().asRemote(tx()).getRelates(roleLabel);
+    const roleType = await (get(var1) as Relation).type.asRemote(tx()).getRelates(roleLabel);
     assert(await (get(var1) as Relation).asRemote(tx()).getPlayers([roleType]).some(x => x.equals(get(var2))));
 });
 
 When("relation {var} get players for role\\({type_label}) do not contain: {var}", async (var1: string, roleLabel: string, var2: string) => {
-    const roleType = await (get(var1) as Relation).getType().asRemote(tx()).getRelates(roleLabel);
+    const roleType = await (get(var1) as Relation).type.asRemote(tx()).getRelates(roleLabel);
     assert(!(await (get(var1) as Relation).asRemote(tx()).getPlayers([roleType]).some(x => x.equals(get(var2)))));
 });

--- a/test/behaviour/concept/type/attributetype/AttributeTypeSteps.ts
+++ b/test/behaviour/concept/type/attributetype/AttributeTypeSteps.ts
@@ -28,20 +28,20 @@ import { tx } from "../../../connection/ConnectionStepsBase";
 import ValueType = AttributeType.ValueType;
 
 When("put attribute type: {type_label}, with value type: {value_type}", async (typeLabel: string, valueType: ValueType) => {
-    await tx().concepts().putAttributeType(typeLabel, valueType);
+    await tx().concepts.putAttributeType(typeLabel, valueType);
 });
 
 Then("attribute\\({type_label}) get value type: {value_type}", async (typeLabel: string, valueType: ValueType) => {
-    assert.strictEqual((await tx().concepts().getAttributeType(typeLabel)).getValueType(), valueType);
+    assert.strictEqual((await tx().concepts.getAttributeType(typeLabel)).valueType, valueType);
 });
 
 Then("attribute\\({type_label}) get supertype value type: {value_type}", async (typeLabel: string, valueType: ValueType) => {
-    const supertype = await (await tx().concepts().getAttributeType(typeLabel)).asRemote(tx()).getSupertype();
-    assert.strictEqual((supertype as AttributeType).getValueType(), valueType);
+    const supertype = await (await tx().concepts.getAttributeType(typeLabel)).asRemote(tx()).getSupertype();
+    assert.strictEqual((supertype as AttributeType).valueType, valueType);
 });
 
 async function attributeTypeAsValueType(typeLabel: string, valueType: ValueType) {
-    const attributeType = await tx().concepts().getAttributeType(typeLabel);
+    const attributeType = await tx().concepts.getAttributeType(typeLabel);
     switch (valueType) {
         case ValueType.OBJECT:
             return attributeType;
@@ -63,14 +63,14 @@ async function attributeTypeAsValueType(typeLabel: string, valueType: ValueType)
 Then("attribute\\({type_label}) as\\({value_type}) get subtypes contain:", async (typeLabel: string, valueType: ValueType, subLabelsTable: DataTable) => {
     const subLabels = parseList(subLabelsTable);
     const attributeType = await attributeTypeAsValueType(typeLabel, valueType);
-    const actuals = await attributeType.asRemote(tx()).getSubtypes().map(tt => tt.getLabel().scopedName()).collect();
+    const actuals = await attributeType.asRemote(tx()).getSubtypes().map(tt => tt.label.scopedName).collect();
     await subLabels.every(sl => assert(actuals.includes(sl)));
 });
 
 Then("attribute\\({type_label}) as\\({value_type}) get subtypes do not contain:", async (typeLabel: string, valueType: ValueType, subLabelsTable: DataTable) => {
     const subLabels = parseList(subLabelsTable);
     const attributeType = await attributeTypeAsValueType(typeLabel, valueType);
-    const actuals = await attributeType.asRemote(tx()).getSubtypes().map(tt => tt.getLabel().scopedName()).collect();
+    const actuals = await attributeType.asRemote(tx()).getSubtypes().map(tt => tt.label.scopedName).collect();
     await subLabels.every(sl => assert(!actuals.includes(sl)));
 });
 
@@ -100,28 +100,28 @@ Then("attribute\\({type_label}) as\\({value_type}) does not have any regex", asy
 
 Then("attribute\\({type_label}) get key owners contain:", async (typeLabel: string, ownerLabelsTable: DataTable) => {
     const ownerLabels = parseList(ownerLabelsTable);
-    const attributeType = await tx().concepts().getAttributeType(typeLabel);
-    const actuals = await attributeType.asRemote(tx()).getOwners(true).map(tt => tt.getLabel().scopedName()).collect();
+    const attributeType = await tx().concepts.getAttributeType(typeLabel);
+    const actuals = await attributeType.asRemote(tx()).getOwners(true).map(tt => tt.label.scopedName).collect();
     await ownerLabels.every(ol => assert(actuals.includes(ol)));
 });
 
 Then("attribute\\({type_label}) get key owners do not contain:", async (typeLabel: string, ownerLabelsTable: DataTable) => {
     const ownerLabels = parseList(ownerLabelsTable);
-    const attributeType = await tx().concepts().getAttributeType(typeLabel);
-    const actuals = await attributeType.asRemote(tx()).getOwners(true).map(tt => tt.getLabel().scopedName()).collect();
+    const attributeType = await tx().concepts.getAttributeType(typeLabel);
+    const actuals = await attributeType.asRemote(tx()).getOwners(true).map(tt => tt.label.scopedName).collect();
     await ownerLabels.every(ol => assert(!actuals.includes(ol)));
 });
 
 Then("attribute\\({type_label}) get attribute owners contain:", async (typeLabel: string, ownerLabelsTable: DataTable) => {
     const ownerLabels = parseList(ownerLabelsTable);
-    const attributeType = await tx().concepts().getAttributeType(typeLabel);
-    const actuals = await attributeType.asRemote(tx()).getOwners(false).map(tt => tt.getLabel().scopedName()).collect();
+    const attributeType = await tx().concepts.getAttributeType(typeLabel);
+    const actuals = await attributeType.asRemote(tx()).getOwners(false).map(tt => tt.label.scopedName).collect();
     await ownerLabels.every(ol => assert(actuals.includes(ol)));
 });
 
 Then("attribute\\({type_label}) get attribute owners do not contain:", async (typeLabel: string, ownerLabelsTable: DataTable) => {
     const ownerLabels = parseList(ownerLabelsTable);
-    const attributeType = await tx().concepts().getAttributeType(typeLabel);
-    const actuals = await attributeType.asRemote(tx()).getOwners(false).map(tt => tt.getLabel().scopedName()).collect();
+    const attributeType = await tx().concepts.getAttributeType(typeLabel);
+    const actuals = await attributeType.asRemote(tx()).getOwners(false).map(tt => tt.label.scopedName).collect();
     await ownerLabels.every(ol => assert(!actuals.includes(ol)));
 });

--- a/test/behaviour/concept/type/relationtype/RelationTypeSteps.ts
+++ b/test/behaviour/concept/type/relationtype/RelationTypeSteps.ts
@@ -28,55 +28,55 @@ import assert = require("assert");
 
 
 When("relation\\({type_label}) set relates role: {type_label}", async (relationLabel: string, roleLabel: string) => {
-    await (await tx().concepts().getRelationType(relationLabel)).asRemote(tx()).setRelates(roleLabel);
+    await (await tx().concepts.getRelationType(relationLabel)).asRemote(tx()).setRelates(roleLabel);
 });
 
 When("relation\\({type_label}) set relates role: {type_label}; throws exception", async (relationLabel: string, roleLabel: string) => {
-    await assertThrows(async () => await (await tx().concepts().getRelationType(relationLabel)).asRemote(tx()).setRelates(roleLabel));
+    await assertThrows(async () => await (await tx().concepts.getRelationType(relationLabel)).asRemote(tx()).setRelates(roleLabel));
 });
 
 When("relation\\({type_label}) unset related role: {type_label}", async (relationLabel: string, roleLabel: string) => {
-    await (await tx().concepts().getRelationType(relationLabel)).asRemote(tx()).unsetRelates(roleLabel);
+    await (await tx().concepts.getRelationType(relationLabel)).asRemote(tx()).unsetRelates(roleLabel);
 });
 
 When("relation\\({type_label}) unset related role: {type_label}; throws exception", async (relationLabel: string, roleLabel: string) => {
-    await assertThrows(async () => await (await tx().concepts().getRelationType(relationLabel)).asRemote(tx()).unsetRelates(roleLabel));
+    await assertThrows(async () => await (await tx().concepts.getRelationType(relationLabel)).asRemote(tx()).unsetRelates(roleLabel));
 });
 
 When("relation\\({type_label}) set relates role: {type_label} as {type_label}", async (relationLabel: string, roleLabel: string, superRole: string) => {
-    await (await tx().concepts().getRelationType(relationLabel)).asRemote(tx()).setRelates(roleLabel, superRole);
+    await (await tx().concepts.getRelationType(relationLabel)).asRemote(tx()).setRelates(roleLabel, superRole);
 });
 
 When("relation\\({type_label}) set relates role: {type_label} as {type_label}; throws exception", async (relationLabel: string, roleLabel: string, superRole: string) => {
-    await assertThrows(async () => await (await tx().concepts().getRelationType(relationLabel)).asRemote(tx()).setRelates(roleLabel, superRole));
+    await assertThrows(async () => await (await tx().concepts.getRelationType(relationLabel)).asRemote(tx()).setRelates(roleLabel, superRole));
 });
 
 When("relation\\({type_label}) remove related role: {type_label}", async (relationLabel: string, roleLabel: string) => {
-    const relatedRole = await (await tx().concepts().getRelationType(relationLabel)).asRemote(tx()).getRelates(roleLabel);
+    const relatedRole = await (await tx().concepts.getRelationType(relationLabel)).asRemote(tx()).getRelates(roleLabel);
     await relatedRole.asRemote(tx()).delete();
 });
 
 Then("relation\\({type_label}) get role\\({type_label}) is null: {bool}", async (relationLabel: string, roleLabel: string, isNull: boolean) => {
-    assert.strictEqual(!(await (await tx().concepts().getRelationType(relationLabel)).asRemote(tx()).getRelates(roleLabel)), isNull);
+    assert.strictEqual(!(await (await tx().concepts.getRelationType(relationLabel)).asRemote(tx()).getRelates(roleLabel)), isNull);
 });
 
 When("relation\\({type_label}) get role\\({type_label}) set label: {type_label}", async (relationLabel: string, roleLabel: string, newLabel: string) => {
-    const roleType = await (await tx().concepts().getRelationType(relationLabel)).asRemote(tx()).getRelates(roleLabel);
+    const roleType = await (await tx().concepts.getRelationType(relationLabel)).asRemote(tx()).getRelates(roleLabel);
     await roleType.asRemote(tx()).setLabel(newLabel);
 });
 
 When("relation\\({type_label}) get role\\({type_label}) get label: {type_label}", async (relationLabel: string, roleLabel: string, getLabel: string) => {
-    const roleType = await (await tx().concepts().getRelationType(relationLabel)).asRemote(tx()).getRelates(roleLabel);
-    assert.strictEqual(roleType.getLabel().name(), getLabel);
+    const roleType = await (await tx().concepts.getRelationType(relationLabel)).asRemote(tx()).getRelates(roleLabel);
+    assert.strictEqual(roleType.label.name, getLabel);
 });
 
 When("relation\\({type_label}) get role\\({type_label}) is abstract: {bool}", async (relationLabel: string, roleLabel: string, isAbstract: boolean) => {
-    const roleType = await (await tx().concepts().getRelationType(relationLabel)).asRemote(tx()).getRelates(roleLabel);
+    const roleType = await (await tx().concepts.getRelationType(relationLabel)).asRemote(tx()).getRelates(roleLabel);
     assert.strictEqual(await roleType.asRemote(tx()).isAbstract(), isAbstract);
 });
 
 async function getActualRelatedRoles(relationLabel: string) {
-    return ((await tx().concepts().getRelationType(relationLabel)).asRemote(tx()).getRelates()).map(role => role.getLabel().scopedName()).collect();
+    return ((await tx().concepts.getRelationType(relationLabel)).asRemote(tx()).getRelates()).map(role => role.label.scopedName).collect();
 }
 
 Then("relation\\({type_label}) get related roles contain:", async (relationLabel: string, roleLabelsTable: DataTable) => {
@@ -92,14 +92,14 @@ Then("relation\\({type_label}) get related roles do not contain:", async (relati
 });
 
 Then("relation\\({type_label}) get role\\({type_label}) get supertype: {scoped_label}", async (relationLabel: string, roleLabel: string, superLabel: ScopedLabel) => {
-    const roleType = await (await tx().concepts().getRelationType(relationLabel)).asRemote(tx()).getRelates(roleLabel);
-    const superType = await (await tx().concepts().getRelationType(superLabel.scope())).asRemote(tx()).getRelates(superLabel.role());
+    const roleType = await (await tx().concepts.getRelationType(relationLabel)).asRemote(tx()).getRelates(roleLabel);
+    const superType = await (await tx().concepts.getRelationType(superLabel.scope)).asRemote(tx()).getRelates(superLabel.role);
     assert((await roleType.asRemote(tx()).getSupertype()).equals(superType));
 });
 
 async function getActualSupertypesForRelatedRole(relationLabel: string, roleLabel: string) {
-    const roleType = await (await tx().concepts().getRelationType(relationLabel)).asRemote(tx()).getRelates(roleLabel);
-    return roleType.asRemote(tx()).getSupertypes().map(role => role.getLabel().scopedName()).collect();
+    const roleType = await (await tx().concepts.getRelationType(relationLabel)).asRemote(tx()).getRelates(roleLabel);
+    return roleType.asRemote(tx()).getSupertypes().map(role => role.label.scopedName).collect();
 }
 
 Then("relation\\({type_label}) get role\\({type_label}) get supertypes contain:", async (relationLabel: string, roleLabel: string, superLabelsTable: DataTable) => {
@@ -115,8 +115,8 @@ Then("relation\\({type_label}) get role\\({type_label}) get supertypes do not co
 });
 
 async function getActualPlayersForRelatedRole(relationLabel: string, roleLabel: string) {
-    const roleType = await (await tx().concepts().getRelationType(relationLabel)).asRemote(tx()).getRelates(roleLabel);
-    return await roleType.asRemote(tx()).getPlayers().map(tt => tt.getLabel().scopedName()).collect();
+    const roleType = await (await tx().concepts.getRelationType(relationLabel)).asRemote(tx()).getRelates(roleLabel);
+    return await roleType.asRemote(tx()).getPlayers().map(tt => tt.label.scopedName).collect();
 }
 
 Then("relation\\({type_label}) get role\\({type_label}) get players contain:", async (relationLabel: string, roleLabel: string, playerLabelsTable: DataTable) => {
@@ -132,8 +132,8 @@ Then("relation\\({type_label}) get role\\({type_label}) get players do not conta
 });
 
 async function getActualSubtypesForRelatedRole(relationLabel: string, roleLabel: string) {
-    const roleType = await (await tx().concepts().getRelationType(relationLabel)).asRemote(tx()).getRelates(roleLabel);
-    return roleType.asRemote(tx()).getSubtypes().map(role => role.getLabel().scopedName()).collect();
+    const roleType = await (await tx().concepts.getRelationType(relationLabel)).asRemote(tx()).getRelates(roleLabel);
+    return roleType.asRemote(tx()).getSubtypes().map(role => role.label.scopedName).collect();
 }
 
 Then("relation\\({type_label}) get role\\({type_label}) get subtypes contain:", async (relationLabel: string, roleLabel: string, subLabelsTable: DataTable) => {

--- a/test/behaviour/concept/type/thingtype/ThingTypeSteps.ts
+++ b/test/behaviour/concept/type/thingtype/ThingTypeSteps.ts
@@ -30,11 +30,11 @@ import { assertThrows } from "../../../util/Util";
 export function getThingType(rootLabel: RootLabel, typeLabel: string): Promise<ThingType> {
     switch (rootLabel) {
         case RootLabel.ENTITY:
-            return tx().concepts().getEntityType(typeLabel);
+            return tx().concepts.getEntityType(typeLabel);
         case RootLabel.ATTRIBUTE:
-            return tx().concepts().getAttributeType(typeLabel);
+            return tx().concepts.getAttributeType(typeLabel);
         case RootLabel.RELATION:
-            return tx().concepts().getRelationType(typeLabel);
+            return tx().concepts.getRelationType(typeLabel);
         default:
             throw "Unsupported type"
     }
@@ -42,35 +42,35 @@ export function getThingType(rootLabel: RootLabel, typeLabel: string): Promise<T
 
 When("thing type root get supertypes contain:", async (supertypesTable: DataTable) => {
     const supertypes = parseList(supertypesTable);
-    const actuals = await (await tx().concepts().getRootThingType()).asRemote(tx()).getSupertypes().map(tt => tt.getLabel().scopedName()).collect();
+    const actuals = await (await tx().concepts.getRootThingType()).asRemote(tx()).getSupertypes().map(tt => tt.label.scopedName).collect();
     supertypes.every(st => assert(actuals.includes(st)));
 });
 
 When("thing type root get supertypes do not contain:", async (supertypesTable: DataTable) => {
     const supertypes = parseList(supertypesTable);
-    const actuals = await (await tx().concepts().getRootThingType()).asRemote(tx()).getSupertypes().map(tt => tt.getLabel().scopedName()).collect();
+    const actuals = await (await tx().concepts.getRootThingType()).asRemote(tx()).getSupertypes().map(tt => tt.label.scopedName).collect();
     supertypes.every(st => assert(!actuals.includes(st)));
 });
 
 When("thing type root get subtypes contain:", async (subtypesTable: DataTable) => {
     const subtypes = parseList(subtypesTable);
-    const actuals = await (await tx().concepts().getRootThingType()).asRemote(tx()).getSubtypes().map(tt => tt.getLabel().scopedName()).collect();
+    const actuals = await (await tx().concepts.getRootThingType()).asRemote(tx()).getSubtypes().map(tt => tt.label.scopedName).collect();
     subtypes.every(st => assert(actuals.includes(st)));
 });
 
 When("thing type root get subtypes do not contain:", async (subtypesTable: DataTable) => {
     const subtypes = parseList(subtypesTable);
-    const actuals = await (await tx().concepts().getRootThingType()).asRemote(tx()).getSubtypes().map(tt => tt.getLabel().scopedName()).collect();
+    const actuals = await (await tx().concepts.getRootThingType()).asRemote(tx()).getSubtypes().map(tt => tt.label.scopedName).collect();
     subtypes.every(st => assert(!actuals.includes(st)));
 });
 
 When("put {root_label} type: {type_label}", async (rootLabel: RootLabel, typeLabel: string) => {
     switch (rootLabel) {
         case RootLabel.ENTITY:
-            await tx().concepts().putEntityType(typeLabel);
+            await tx().concepts.putEntityType(typeLabel);
             break;
         case RootLabel.RELATION:
-            await tx().concepts().putRelationType(typeLabel);
+            await tx().concepts.putRelationType(typeLabel);
             break;
         default:
             throw `Could not put ${typeLabel} of type Attribute`;
@@ -94,7 +94,7 @@ When("{root_label}\\({type_label}) set label: {type_label}", async (rootLabel: R
 });
 
 When("{root_label}\\({type_label}) get label: {type_label}", async (rootLabel: RootLabel, typeLabel: string, label: string) => {
-    await assert.strictEqual((await getThingType(rootLabel, typeLabel)).asRemote(tx()).getLabel().scopedName(), label);
+    await assert.strictEqual((await getThingType(rootLabel, typeLabel)).asRemote(tx()).label.scopedName, label);
 });
 
 When("{root_label}\\({type_label}) set abstract: {bool}", async (rootLabel: RootLabel, typeLabel: string, isAbstract: boolean) => {
@@ -112,16 +112,16 @@ When("{root_label}\\({type_label}) is abstract: {bool}", async (rootLabel: RootL
 When("{root_label}\\({type_label}) set supertype: {type_label}", async (rootLabel: RootLabel, typeLabel: string, superLabel: string) => {
     switch (rootLabel) {
         case RootLabel.ENTITY: {
-            const entitySuperType = await tx().concepts().getEntityType(superLabel);
-            return await (await tx().concepts().getEntityType(typeLabel)).asRemote(tx()).setSupertype(entitySuperType);
+            const entitySuperType = await tx().concepts.getEntityType(superLabel);
+            return await (await tx().concepts.getEntityType(typeLabel)).asRemote(tx()).setSupertype(entitySuperType);
         }
         case RootLabel.ATTRIBUTE: {
-            const attributeSuperType = await tx().concepts().getAttributeType(superLabel);
-            return await (await tx().concepts().getAttributeType(typeLabel)).asRemote(tx()).setSupertype(attributeSuperType);
+            const attributeSuperType = await tx().concepts.getAttributeType(superLabel);
+            return await (await tx().concepts.getAttributeType(typeLabel)).asRemote(tx()).setSupertype(attributeSuperType);
         }
         case RootLabel.RELATION: {
-            const relationSuperType = await tx().concepts().getRelationType(superLabel);
-            return await (await tx().concepts().getRelationType(typeLabel)).asRemote(tx()).setSupertype(relationSuperType);
+            const relationSuperType = await tx().concepts.getRelationType(superLabel);
+            return await (await tx().concepts.getRelationType(typeLabel)).asRemote(tx()).setSupertype(relationSuperType);
         }
     }
 });
@@ -129,16 +129,16 @@ When("{root_label}\\({type_label}) set supertype: {type_label}", async (rootLabe
 When("{root_label}\\({type_label}) set supertype: {type_label}; throws exception", async (rootLabel: RootLabel, typeLabel: string, superLabel: string) => {
     switch (rootLabel) {
         case RootLabel.ENTITY: {
-            const entitySuperType = await tx().concepts().getEntityType(superLabel);
-            return await assertThrows(async () => await (await tx().concepts().getEntityType(typeLabel)).asRemote(tx()).setSupertype(entitySuperType));
+            const entitySuperType = await tx().concepts.getEntityType(superLabel);
+            return await assertThrows(async () => await (await tx().concepts.getEntityType(typeLabel)).asRemote(tx()).setSupertype(entitySuperType));
         }
         case RootLabel.ATTRIBUTE: {
-            const attributeSuperType = await tx().concepts().getAttributeType(superLabel);
-            return await assertThrows(async () => await (await tx().concepts().getAttributeType(typeLabel)).asRemote(tx()).setSupertype(attributeSuperType));
+            const attributeSuperType = await tx().concepts.getAttributeType(superLabel);
+            return await assertThrows(async () => await (await tx().concepts.getAttributeType(typeLabel)).asRemote(tx()).setSupertype(attributeSuperType));
         }
         case RootLabel.RELATION: {
-            const relationSuperType = await tx().concepts().getRelationType(superLabel);
-            return await assertThrows(async () => await (await tx().concepts().getRelationType(typeLabel)).asRemote(tx()).setSupertype(relationSuperType));
+            const relationSuperType = await tx().concepts.getRelationType(superLabel);
+            return await assertThrows(async () => await (await tx().concepts.getRelationType(typeLabel)).asRemote(tx()).setSupertype(relationSuperType));
         }
     }
 });
@@ -151,154 +151,154 @@ Then("{root_label}\\({type_label}) get supertype: {type_label}", async (rootLabe
 Then("{root_label}\\({type_label}) get supertypes contain:", async (rootLabel: RootLabel, typeLabel: string, superLabelsTable: DataTable) => {
     const superLabels = parseList(superLabelsTable);
     const thingType = await getThingType(rootLabel, typeLabel);
-    const actuals = await thingType.asRemote(tx()).getSupertypes().map(tt => tt.getLabel().scopedName()).collect();
+    const actuals = await thingType.asRemote(tx()).getSupertypes().map(tt => tt.label.scopedName).collect();
     superLabels.every(sl => assert(actuals.includes(sl)));
 });
 
 Then("{root_label}\\({type_label}) get supertypes do not contain:", async (rootLabel: RootLabel, typeLabel: string, superLabelsTable: DataTable) => {
     const superLabels = parseList(superLabelsTable);
     const thingType = await getThingType(rootLabel, typeLabel);
-    const actuals = await thingType.asRemote(tx()).getSupertypes().map(tt => tt.getLabel().scopedName()).collect();
+    const actuals = await thingType.asRemote(tx()).getSupertypes().map(tt => tt.label.scopedName).collect();
     superLabels.every(sl => assert(!actuals.includes(sl)));
 });
 
 Then("{root_label}\\({type_label}) get subtypes contain:", async (rootLabel: RootLabel, typeLabel: string, subLabelsTable: DataTable) => {
     const subLabels = parseList(subLabelsTable);
     const thingType = await getThingType(rootLabel, typeLabel);
-    const actuals = await thingType.asRemote(tx()).getSubtypes().map(tt => tt.getLabel().scopedName()).collect();
+    const actuals = await thingType.asRemote(tx()).getSubtypes().map(tt => tt.label.scopedName).collect();
     subLabels.every(sl => assert(actuals.includes(sl)));
 });
 
 Then("{root_label}\\({type_label}) get subtypes do not contain:", async (rootLabel: RootLabel, typeLabel: string, subLabelsTable: DataTable) => {
     const subLabels = parseList(subLabelsTable);
     const thingType = await getThingType(rootLabel, typeLabel);
-    const actuals = await thingType.asRemote(tx()).getSubtypes().map(tt => tt.getLabel().scopedName()).collect();
+    const actuals = await thingType.asRemote(tx()).getSubtypes().map(tt => tt.label.scopedName).collect();
     subLabels.every(sl => assert(!actuals.includes(sl)));
 });
 
 When("{root_label}\\({type_label}) set owns key type: {type_label}", async (rootLabel: RootLabel, typeLabel: string, attTypeLabel: string) => {
-    const attributeType = await tx().concepts().getAttributeType(attTypeLabel);
+    const attributeType = await tx().concepts.getAttributeType(attTypeLabel);
     await (await getThingType(rootLabel, typeLabel)).asRemote(tx()).setOwns(attributeType, true);
 });
 
 When("{root_label}\\({type_label}) set owns key type: {type_label} as {type_label}", async (rootLabel: RootLabel, typeLabel: string, attTypeLabel: string, overriddenLabel: string) => {
-    const attributeType = await tx().concepts().getAttributeType(attTypeLabel);
-    const overriddenType = await tx().concepts().getAttributeType(overriddenLabel);
+    const attributeType = await tx().concepts.getAttributeType(attTypeLabel);
+    const overriddenType = await tx().concepts.getAttributeType(overriddenLabel);
     await (await getThingType(rootLabel, typeLabel)).asRemote(tx()).setOwns(attributeType, overriddenType, true);
 });
 
 Then("{root_label}\\({type_label}) set owns key type: {type_label}; throws exception", async (rootLabel: RootLabel, typeLabel: string, attributeLabel: string) => {
-    const attributeType = await tx().concepts().getAttributeType(attributeLabel);
+    const attributeType = await tx().concepts.getAttributeType(attributeLabel);
     await assertThrows(async () => await (await getThingType(rootLabel, typeLabel)).asRemote(tx()).setOwns(attributeType, true));
 });
 
 Then("{root_label}\\({type_label}) set owns key type: {type_label} as {type_label}; throws exception", async (rootLabel: RootLabel, typeLabel: string, attributeLabel: string, overriddenLabel: string) => {
-    const attributeType = await tx().concepts().getAttributeType(attributeLabel);
-    const overriddenType = await tx().concepts().getAttributeType(overriddenLabel);
+    const attributeType = await tx().concepts.getAttributeType(attributeLabel);
+    const overriddenType = await tx().concepts.getAttributeType(overriddenLabel);
     await assertThrows(async () => await (await getThingType(rootLabel, typeLabel)).asRemote(tx()).setOwns(attributeType, overriddenType, true));
 });
 
 When("{root_label}\\({type_label}) unset owns key type: {type_label}", async (rootLabel: RootLabel, typeLabel: string, attributeLabel: string) => {
-    const attributeType = await tx().concepts().getAttributeType(attributeLabel);
+    const attributeType = await tx().concepts.getAttributeType(attributeLabel);
     await (await getThingType(rootLabel, typeLabel)).asRemote(tx()).unsetOwns(attributeType);
 });
 
 Then("{root_label}\\({type_label}) get owns key types contain:", async (rootLabel: RootLabel, typeLabel: string, attributeLabelsTable: DataTable) => {
     const attributeLabels = parseList(attributeLabelsTable);
-    const actuals = await (await getThingType(rootLabel, typeLabel)).asRemote(tx()).getOwns(true).map(tt => tt.getLabel().scopedName()).collect();
+    const actuals = await (await getThingType(rootLabel, typeLabel)).asRemote(tx()).getOwns(true).map(tt => tt.label.scopedName).collect();
     attributeLabels.every(al => assert(actuals.includes(al)));
 });
 
 Then("{root_label}\\({type_label}) get owns key types do not contain:", async (rootLabel: RootLabel, typeLabel: string, attributeLabelsTable: DataTable) => {
     const attributeLabels = parseList(attributeLabelsTable);
-    const actuals = await (await getThingType(rootLabel, typeLabel)).asRemote(tx()).getOwns(true).map(tt => tt.getLabel().scopedName()).collect();
+    const actuals = await (await getThingType(rootLabel, typeLabel)).asRemote(tx()).getOwns(true).map(tt => tt.label.scopedName).collect();
     attributeLabels.every(al => assert(!actuals.includes(al)));
 });
 
 When("{root_label}\\({type_label}) set owns attribute type: {type_label}", async (rootLabel: RootLabel, typeLabel: string, attributeLabel: string) => {
-    const attributeType = await tx().concepts().getAttributeType(attributeLabel);
+    const attributeType = await tx().concepts.getAttributeType(attributeLabel);
     await (await getThingType(rootLabel, typeLabel)).asRemote(tx()).setOwns(attributeType);
 });
 
 Then("{root_label}\\({type_label}) set owns attribute type: {type_label}; throws exception", async (rootLabel: RootLabel, typeLabel: string, attributeLabel: string) => {
-    const attributeType = await tx().concepts().getAttributeType(attributeLabel);
+    const attributeType = await tx().concepts.getAttributeType(attributeLabel);
     await assertThrows(async () => await (await getThingType(rootLabel, typeLabel)).asRemote(tx()).setOwns(attributeType));
 });
 
 When("{root_label}\\({type_label}) set owns attribute type: {type_label} as {type_label}", async (rootLabel: RootLabel, typeLabel: string, attributeLabel: string, overriddenLabel: string) => {
-    const attributeType = await tx().concepts().getAttributeType(attributeLabel);
-    const overriddenType = await tx().concepts().getAttributeType(overriddenLabel);
+    const attributeType = await tx().concepts.getAttributeType(attributeLabel);
+    const overriddenType = await tx().concepts.getAttributeType(overriddenLabel);
     await (await getThingType(rootLabel, typeLabel)).asRemote(tx()).setOwns(attributeType, overriddenType);
 });
 
 Then("{root_label}\\({type_label}) set owns attribute type: {type_label} as {type_label}; throws exception", async (rootLabel: RootLabel, typeLabel: string, attributeLabel: string, overriddenLabel: string) => {
-    const attributeType = await tx().concepts().getAttributeType(attributeLabel);
-    const overriddenType = await tx().concepts().getAttributeType(overriddenLabel);
+    const attributeType = await tx().concepts.getAttributeType(attributeLabel);
+    const overriddenType = await tx().concepts.getAttributeType(overriddenLabel);
     await assertThrows(async () => await (await getThingType(rootLabel, typeLabel)).asRemote(tx()).setOwns(attributeType, overriddenType));
 });
 
 When("{root_label}\\({type_label}) unset owns attribute type: {type_label}", async (rootLabel: RootLabel, typeLabel: string, attributeLabel: string) => {
-    const attributeType = await tx().concepts().getAttributeType(attributeLabel);
+    const attributeType = await tx().concepts.getAttributeType(attributeLabel);
     await (await getThingType(rootLabel, typeLabel)).asRemote(tx()).unsetOwns(attributeType);
 });
 
 When("{root_label}\\({type_label}) unset owns attribute type: {type_label}; throws exception", async (rootLabel: RootLabel, typeLabel: string, attributeLabel: string) => {
-    const attributeType = await tx().concepts().getAttributeType(attributeLabel);
+    const attributeType = await tx().concepts.getAttributeType(attributeLabel);
     await assertThrows(async () => await (await getThingType(rootLabel, typeLabel)).asRemote(tx()).unsetOwns(attributeType));
 });
 
 Then("{root_label}\\({type_label}) get owns attribute types contain:", async (rootLabel: RootLabel, typeLabel: string, attributeLabelsTable: DataTable) => {
     const attributeLabels = parseList(attributeLabelsTable);
-    const actuals = await (await getThingType(rootLabel, typeLabel)).asRemote(tx()).getOwns().map(tt => tt.getLabel().scopedName()).collect();
+    const actuals = await (await getThingType(rootLabel, typeLabel)).asRemote(tx()).getOwns().map(tt => tt.label.scopedName).collect();
     attributeLabels.every(al => assert(actuals.includes(al)));
 });
 
 Then("{root_label}\\({type_label}) get owns attribute types do not contain:", async (rootLabel: RootLabel, typeLabel: string, attributeLabelsTable: DataTable) => {
     const attributeLabels = parseList(attributeLabelsTable);
-    const actuals = await (await getThingType(rootLabel, typeLabel)).asRemote(tx()).getOwns().map(tt => tt.getLabel().scopedName()).collect();
+    const actuals = await (await getThingType(rootLabel, typeLabel)).asRemote(tx()).getOwns().map(tt => tt.label.scopedName).collect();
     attributeLabels.every(al => assert(!actuals.includes(al)));
 });
 
 When("{root_label}\\({type_label}) set plays role: {scoped_label}", async (rootLabel: RootLabel, typeLabel: string, roleLabel: ScopedLabel) => {
-    const roleType = await (await tx().concepts().getRelationType(roleLabel.scope())).asRemote(tx()).getRelates(roleLabel.role());
+    const roleType = await (await tx().concepts.getRelationType(roleLabel.scope)).asRemote(tx()).getRelates(roleLabel.role);
     await (await getThingType(rootLabel, typeLabel)).asRemote(tx()).setPlays(roleType);
 });
 
 When("{root_label}\\({type_label}) set plays role: {scoped_label}; throws exception", async (rootLabel: RootLabel, typeLabel: string, roleLabel: ScopedLabel) => {
-    const roleType = await (await tx().concepts().getRelationType(roleLabel.scope())).asRemote(tx()).getRelates(roleLabel.role());
+    const roleType = await (await tx().concepts.getRelationType(roleLabel.scope)).asRemote(tx()).getRelates(roleLabel.role);
     await assertThrows(async () => await (await getThingType(rootLabel, typeLabel)).asRemote(tx()).setPlays(roleType));
 });
 
 When("{root_label}\\({type_label}) set plays role: {scoped_label} as {scoped_label}", async (rootLabel: RootLabel, typeLabel: string, roleLabel: ScopedLabel, overriddenLabel: ScopedLabel) => {
-    const roleType = await (await tx().concepts().getRelationType(roleLabel.scope())).asRemote(tx()).getRelates(roleLabel.role());
-    const overriddenType = await (await tx().concepts().getRelationType(overriddenLabel.scope())).asRemote(tx()).getRelates(overriddenLabel.role());
+    const roleType = await (await tx().concepts.getRelationType(roleLabel.scope)).asRemote(tx()).getRelates(roleLabel.role);
+    const overriddenType = await (await tx().concepts.getRelationType(overriddenLabel.scope)).asRemote(tx()).getRelates(overriddenLabel.role);
     await (await getThingType(rootLabel, typeLabel)).asRemote(tx()).setPlays(roleType, overriddenType);
 });
 
 When("{root_label}\\({type_label}) set plays role: {scoped_label} as {scoped_label}; throws exception", async (rootLabel: RootLabel, typeLabel: string, roleLabel: ScopedLabel, overriddenLabel: ScopedLabel) => {
-    const roleType = await (await tx().concepts().getRelationType(roleLabel.scope())).asRemote(tx()).getRelates(roleLabel.role());
-    const overriddenType = await (await tx().concepts().getRelationType(overriddenLabel.scope())).asRemote(tx()).getRelates(overriddenLabel.role());
+    const roleType = await (await tx().concepts.getRelationType(roleLabel.scope)).asRemote(tx()).getRelates(roleLabel.role);
+    const overriddenType = await (await tx().concepts.getRelationType(overriddenLabel.scope)).asRemote(tx()).getRelates(overriddenLabel.role);
     await assertThrows(async () => await (await getThingType(rootLabel, typeLabel)).asRemote(tx()).setPlays(roleType, overriddenType));
 });
 
 When("{root_label}\\({type_label}) unset plays role: {scoped_label}", async (rootLabel: RootLabel, typeLabel: string, roleLabel: ScopedLabel) => {
-    const roleType = await (await tx().concepts().getRelationType(roleLabel.scope())).asRemote(tx()).getRelates(roleLabel.role());
+    const roleType = await (await tx().concepts.getRelationType(roleLabel.scope)).asRemote(tx()).getRelates(roleLabel.role);
     await (await getThingType(rootLabel, typeLabel)).asRemote(tx()).unsetPlays(roleType);
 });
 
 When("{root_label}\\({type_label}) unset plays role: {scoped_label}; throws exception", async (rootLabel: RootLabel, typeLabel: string, roleLabel: ScopedLabel) => {
-    const roleType = await (await tx().concepts().getRelationType(roleLabel.scope())).asRemote(tx()).getRelates(roleLabel.role());
+    const roleType = await (await tx().concepts.getRelationType(roleLabel.scope)).asRemote(tx()).getRelates(roleLabel.role);
     await assertThrows(async () => await (await getThingType(rootLabel, typeLabel)).asRemote(tx()).unsetPlays(roleType));
 });
 
 Then("{root_label}\\({type_label}) get playing roles contain:", async (rootLabel: RootLabel, typeLabel: string, roleLabelsTable: DataTable) => {
     const roleLabels = parseList(roleLabelsTable);
-    const actuals = await (await getThingType(rootLabel, typeLabel)).asRemote(tx()).getPlays().map(r => r.getLabel().scopedName()).collect();
+    const actuals = await (await getThingType(rootLabel, typeLabel)).asRemote(tx()).getPlays().map(r => r.label.scopedName).collect();
     roleLabels.every(rl => assert(actuals.includes(rl)));
 });
 
 Then("{root_label}\\({type_label}) get playing roles do not contain:", async (rootLabel: RootLabel, typeLabel: string, roleLabelsTable: DataTable) => {
     const roleLabels = parseList(roleLabelsTable);
-    const actuals = await (await getThingType(rootLabel, typeLabel)).asRemote(tx()).getPlays().map(r => r.getLabel().scopedName()).collect();
+    const actuals = await (await getThingType(rootLabel, typeLabel)).asRemote(tx()).getPlays().map(r => r.label.scopedName).collect();
     roleLabels.every(rl => assert(!actuals.includes(rl)));
 });

--- a/test/behaviour/config/Parameters.ts
+++ b/test/behaviour/config/Parameters.ts
@@ -77,11 +77,11 @@ export class ScopedLabel {
         return new ScopedLabel(split[0], split[1]);
     }
 
-    scope(): string {
+    get scope(): string {
         return this._scope;
     }
 
-    role(): string {
+    get role(): string {
         return this._role;
     }
 

--- a/test/behaviour/connection/ConnectionStepsBase.ts
+++ b/test/behaviour/connection/ConnectionStepsBase.ts
@@ -47,7 +47,7 @@ Before(async () => {
     for (const session of sessions) {
         await session.close()
     }
-    const databases = await client.databases().all();
+    const databases = await client.databases.all();
     for (const db of databases) {
         await db.delete();
     }
@@ -59,7 +59,7 @@ After(async () => {
     for (const session of sessions) {
         await session.close()
     }
-    for (const db of await client.databases().all()) {
+    for (const db of await client.databases.all()) {
         await db.delete();
     }
 });

--- a/test/behaviour/connection/ConnectionStepsCluster.ts
+++ b/test/behaviour/connection/ConnectionStepsCluster.ts
@@ -23,7 +23,6 @@ import { BeforeAll } from "@cucumber/cucumber";
 import { TypeDB, TypeDBCredential } from "../../../dist";
 import { setClient } from "./ConnectionStepsBase";
 
-
 BeforeAll(async () => {
     setClient(await TypeDB.clusterClient([TypeDB.DEFAULT_ADDRESS], new TypeDBCredential("admin", "password", process.env.ROOT_CA)));
 });

--- a/test/behaviour/connection/database/DatabaseSteps.ts
+++ b/test/behaviour/connection/database/DatabaseSteps.ts
@@ -26,12 +26,12 @@ import { assertThrows } from "../../util/Util";
 import { client, THREAD_POOL_SIZE } from "../ConnectionStepsBase";
 
 When("connection create database: {word}", async (name: string) => {
-    await client.databases().create(name)
+    await client.databases.create(name)
 });
 
 When("connection create database(s):", async (names: DataTable) => {
     for (const name of names.raw()) {
-        await client.databases().create(name[0])
+        await client.databases.create(name[0])
     }
 });
 
@@ -39,26 +39,26 @@ When("connection create databases in parallel:", async (names: DataTable) => {
     assert.ok(THREAD_POOL_SIZE >= names.raw().length);
     const creations: Promise<void>[] = [];
     for (const name of names.raw()) {
-        creations.push(client.databases().create(name[0]));
+        creations.push(client.databases.create(name[0]));
     }
     await Promise.all(creations);
 });
 
 When("connection delete database: {word}", async (name: string) => {
-    const db = await client.databases().get(name);
+    const db = await client.databases.get(name);
     await db.delete();
 });
 
 When("connection delete database(s):", async (names: DataTable) => {
     for (const name of names.raw()) {
-        const db = await client.databases().get(name[0]);
+        const db = await client.databases.get(name[0]);
         await db.delete();
     }
 });
 
 Then("connection delete database; throws exception: {word}", async (name: string) => {
     await assertThrows(async () => {
-        const db = await client.databases().get(name);
+        const db = await client.databases.get(name);
         await db.delete();
     });
 });
@@ -66,7 +66,7 @@ Then("connection delete database; throws exception: {word}", async (name: string
 Then("connection delete database(s); throws exception", async (names: DataTable) => {
     for (const name of names.raw()) {
         await assertThrows(async () => {
-            const db = await client.databases().get(name[0]);
+            const db = await client.databases.get(name[0]);
             await db.delete();
         });
     }
@@ -76,42 +76,42 @@ When("connection delete databases in parallel:", async (names: DataTable) => {
     assert.ok(THREAD_POOL_SIZE >= names.raw().length);
     const deletions: Promise<void>[] = [];
     for (const name of names.raw()) {
-        deletions.push((await client.databases().get(name[0])).delete());
+        deletions.push((await client.databases.get(name[0])).delete());
     }
     await Promise.all(deletions);
 });
 
 When("connection delete all databases", async () => {
-    const databases = await client.databases().all();
+    const databases = await client.databases.all();
     for (const db of databases) {
         await db.delete();
     }
 });
 
 Then("connection has database: {word}", async (name: string) => {
-    const databases = await client.databases().all();
-    assert.ok(databases.some(x => x.name() === name));
+    const databases = await client.databases.all();
+    assert.ok(databases.some(x => x.name === name));
 });
 
 Then("connection has database(s):", async (names: DataTable) => {
-    const databases = await client.databases().all();
+    const databases = await client.databases.all();
     names.raw().forEach(name => {
-        assert.ok(databases.some(x => x.name() === name[0]));
+        assert.ok(databases.some(x => x.name === name[0]));
     });
 });
 
 Then("connection does not have database: {word}", async (name: string) => {
-    assert.ok(!(await client.databases().contains(name)));
+    assert.ok(!(await client.databases.contains(name)));
 });
 
 Then("connection does not have database(s):", async (names: DataTable) => {
-    const databases = await client.databases().all();
+    const databases = await client.databases.all();
     names.raw().forEach(name => {
-        assert.ok(!databases.some(x => x.name() === name[0]));
+        assert.ok(!databases.some(x => x.name === name[0]));
     });
 });
 
 Given("connection does not have any database", async () => {
-    const databases = await client.databases().all();
+    const databases = await client.databases.all();
     assert.ok(databases.length === 0)
 });

--- a/test/behaviour/connection/session/SessionSteps.ts
+++ b/test/behaviour/connection/session/SessionSteps.ts
@@ -79,12 +79,12 @@ Then('session(s)( in parallel) is/are open: {bool}', function (isOpen: boolean) 
 
 When("session has database: {word}", (name: string) => {
     for (const session of sessions) {
-        assert.ok(session.database().name() === name);
+        assert.ok(session.database.name === name);
     }
 });
 
 When("sessions( in parallel) have/has databases:", (names: DataTable) => {
     for (let i = 0; i < sessions.length; i++) {
-        assert.ok(sessions[i].database().name() === names.raw()[i][0]);
+        assert.ok(sessions[i].database.name === names.raw()[i][0]);
     }
 });

--- a/test/behaviour/connection/transaction/TransactionSteps.ts
+++ b/test/behaviour/connection/transaction/TransactionSteps.ts
@@ -114,7 +114,7 @@ Then('(for each )session(,) transaction(s) close(s)', async function () {
 Then('(for each )session(,) transaction(s)( in parallel) has/have type: {transaction_type}', function (type: TransactionType) {
     for (const session of sessions) {
         for (const transaction of sessionsToTransactions.get(session)) {
-            assert(transaction.type() === type);
+            assert(transaction.type === type);
         }
     }
 });
@@ -124,7 +124,7 @@ Then('(for each )session(,) transaction(s)( in parallel) has/have type(s):', fun
     for (const session of sessions) {
         const transactionArray = sessionsToTransactions.get(session)
         for (let i = 0; i < transactionArray.length; i++) {
-            assert(transactionArray[i].type() === typeArray[i]);
+            assert(transactionArray[i].type === typeArray[i]);
         }
     }
 });

--- a/test/behaviour/connection/user/UserSteps.ts
+++ b/test/behaviour/connection/user/UserSteps.ts
@@ -25,31 +25,31 @@ import { client } from "../ConnectionStepsBase";
 import assert = require("assert");
 
 Given("users contains: {word}", async (name: string) => {
-    const users = await getClient().users().all();
-    users.map((user: User) => user.name()).includes(name);
+    const users = await getClient().users.all();
+    users.map((user: User) => user.name).includes(name);
 });
 
 Then("users not contains: {word}", async (name: string) => {
-    const users = await getClient().users().all();
-    !users.map((user: User) => user.name()).includes(name);
+    const users = await getClient().users.all();
+    !users.map((user: User) => user.name).includes(name);
 });
 
 Then("users create: {word}, {word}", async (name: string, password: string) => {
-    await getClient().users().create(name, password);
+    await getClient().users.create(name, password);
 });
 
 Then("user password: {word}, {word}", async (name: string, password: string) => {
-    const user = await getClient().users().get(name);
+    const user = await getClient().users.get(name);
     await user.password(password);
 });
 
 Then("user connect: {word}, {word}", async (name: string, password: string) => {
     const client = await TypeDB.clusterClient([TypeDB.DEFAULT_ADDRESS], new TypeDBCredential(name, password, process.env.ROOT_CA));
-    await client.databases().all()
+    await client.databases.all()
 })
 
 Then("user delete: {word}", async (name: string) => {
-    const user = await getClient().users().get(name);
+    const user = await getClient().users.get(name);
     await user.delete();
 });
 

--- a/test/behaviour/typeql/TypeQLSteps.ts
+++ b/test/behaviour/typeql/TypeQLSteps.ts
@@ -40,110 +40,106 @@ function clearAnswers() {
     numericAnswerGroups.length = 0;
 }
 
-Then("the integrity is validated", async () => {
-    // TODO
-});
-
 When("typeql define", async (query: string) => {
-    await tx().query().define(query);
+    await tx().query.define(query);
 });
 
 Then("typeql define; throws exception containing {string}", async (exceptionString: string, query: string) => {
-    await assertThrowsWithMessage(async () => await tx().query().define(query), exceptionString);
+    await assertThrowsWithMessage(async () => await tx().query.define(query), exceptionString);
 });
 
 Then("typeql define; throws exception", async (query: string) => {
-    await assertThrows(async () => await tx().query().define(query));
+    await assertThrows(async () => await tx().query.define(query));
 });
 
 When("typeql undefine", async (query: string) => {
-    await tx().query().undefine(query);
+    await tx().query.undefine(query);
 });
 
 Then("typeql undefine; throws exception containing {string}", async (exceptionString: string, query: string) => {
-    await assertThrowsWithMessage(async () => await tx().query().undefine(query), exceptionString);
+    await assertThrowsWithMessage(async () => await tx().query.undefine(query), exceptionString);
 });
 
 Then("typeql undefine; throws exception", async (query: string) => {
-    await assertThrows(async () => await tx().query().undefine(query));
+    await assertThrows(async () => await tx().query.undefine(query));
 });
 
 When("typeql insert", async (query: string) => {
-    await tx().query().insert(query).collect();
+    await tx().query.insert(query).collect();
 });
 
 Then("typeql insert; throws exception containing {string}", async (exceptionString: string, query: string) => {
-    await assertThrowsWithMessage(async () => await tx().query().insert(query).first(), exceptionString);
+    await assertThrowsWithMessage(async () => await tx().query.insert(query).first(), exceptionString);
 });
 
 Then("typeql insert; throws exception", async (query: string) => {
-    await assertThrows(async () => await tx().query().insert(query).first());
+    await assertThrows(async () => await tx().query.insert(query).first());
 });
 
 When("typeql delete", async (query: string) => {
-    await tx().query().delete(query);
+    await tx().query.delete(query);
 });
 
 Then("typeql delete; throws exception containing {string}", async (exceptionString: string, query: string) => {
-    await assertThrowsWithMessage(async () => await tx().query().delete(query), exceptionString);
+    await assertThrowsWithMessage(async () => await tx().query.delete(query), exceptionString);
 });
 
 Then("typeql delete; throws exception", async (query: string) => {
-    await assertThrows(async () => await tx().query().delete(query));
+    await assertThrows(async () => await tx().query.delete(query));
 });
 
 When("typeql update", async (query: string) => {
-    await tx().query().update(query).collect();
+    await tx().query.update(query).collect();
 });
 
 Then("typeql update; throws exception containing {string}", async (exceptionString: string, query: string) => {
-    await assertThrowsWithMessage(async () => await tx().query().update(query).first(), exceptionString);
+    await assertThrowsWithMessage(async () => await tx().query.update(query).first(), exceptionString);
 });
 
 Then("typeql update; throws exception", async (query: string) => {
-    await assertThrows(async () => await tx().query().update(query).first());
+    await assertThrows(async () => await tx().query.update(query).first());
 });
 
 When("get answers of typeql insert", async (query: string) => {
     clearAnswers();
-    answers = await tx().query().insert(query).collect();
+    answers = await tx().query.insert(query).collect();
 });
 
 When("get answers of typeql update", async (query: string) => {
     clearAnswers();
-    answers = await tx().query().update(query).collect();
+    answers = await tx().query.update(query).collect();
 });
 
 When("get answers of typeql match", async (query: string) => {
     clearAnswers();
-    answers = await tx().query().match(query).collect();
+    answers = await tx().query.match(query).collect();
 });
 
 Then("typeql match; throws exception", async (query: string) => {
-    await assertThrows(async () => await tx().query().match(query).first());
+    await assertThrows(async () => await tx().query.match(query).first());
 });
 
 When("get answer of typeql match aggregate", async (query: string) => {
     clearAnswers();
-    numericAnswer = await tx().query().matchAggregate(query);
+    numericAnswer = await tx().query.matchAggregate(query);
 });
 
 When("get answers of typeql match group", async (query: string) => {
     clearAnswers();
-    answerGroups = await tx().query().matchGroup(query).collect();
+    answerGroups = await tx().query.matchGroup(query).collect();
 });
 
 When("typeql match group; throws exception", async (query: string) => {
-    await assertThrows(async () => await tx().query().matchGroup(query).first());
+    await assertThrows(async () => await tx().query.matchGroup(query).first());
 })
 
 When("get answers of typeql match group aggregate", async (query: string) => {
     clearAnswers();
-    numericAnswerGroups = await tx().query().matchGroupAggregate(query).collect();
+    numericAnswerGroups = await tx().query.matchGroupAggregate(query).collect();
 });
 
 When("typeql match aggregate; throws exception", async (query: string) => {
-    await assertThrows(async () => await tx().query().matchAggregate(query));
+    await assertThrows(async () => await tx().query.matchAggregate(query));
 
 })
 
@@ -152,15 +148,15 @@ Then("answer size is: {number}", async (expectedAnswers: number) => {
 });
 
 Then("rules contain: {type_label}", async (ruleLabel: string) => {
-    for await (const rule of (await tx().logic().getRules())) {
-        if (rule.getLabel() === ruleLabel) return;
+    for await (const rule of (await tx().logic.getRules())) {
+        if (rule.label === ruleLabel) return;
     }
     assert.fail();
 });
 
 Then("rules do not contain: {type_label}", async (ruleLabel: string) => {
-    for await (const rule of (await tx().logic().getRules())) {
-        if (rule.getLabel() === ruleLabel) assert.fail();
+    for await (const rule of (await tx().logic.getRules())) {
+        if (rule.label === ruleLabel) assert.fail();
     }
 });
 
@@ -180,8 +176,8 @@ class TypeLabelMatcher implements ConceptMatcher {
     }
 
     async matches(concept: Concept): Promise<boolean> {
-        if (concept.isRoleType()) return this.label == (concept as RoleType).getLabel().scopedName();
-        else if (concept.isType()) return this.label == (concept as Type).getLabel().scopedName();
+        if (concept.isRoleType()) return this.label == (concept as RoleType).label.scopedName;
+        else if (concept.isType()) return this.label == (concept as Type).label.scopedName;
         else throw new TypeError("A Concept was matched by label, but it is not a Type.");
     }
 }
@@ -205,11 +201,11 @@ abstract class AttributeMatcher implements ConceptMatcher {
     }
 
     check(attribute: Attribute) {
-        if (attribute.isBoolean()) return attribute.asBoolean().getValue() === parseBool(this.value);
-        else if (attribute.isLong()) return attribute.asLong().getValue() === parseInt(this.value);
-        else if (attribute.isDouble()) return attribute.asDouble().getValue() === parseFloat(this.value);
-        else if (attribute.isString()) return attribute.asString().getValue() === this.value;
-        else if (attribute.isDateTime()) return attribute.asDateTime().getValue().getTime() === new Date(this.value).getTime();
+        if (attribute.isBoolean()) return attribute.asBoolean().value === parseBool(this.value);
+        else if (attribute.isLong()) return attribute.asLong().value === parseInt(this.value);
+        else if (attribute.isDouble()) return attribute.asDouble().value === parseFloat(this.value);
+        else if (attribute.isString()) return attribute.asString().value === this.value;
+        else if (attribute.isDateTime()) return attribute.asDateTime().value.getTime() === new Date(this.value).getTime();
         else throw new Error(`Unrecognised value type ${attribute.constructor.name}`);
     }
 
@@ -223,7 +219,7 @@ class AttributeValueMatcher extends AttributeMatcher {
 
         const attribute = concept as Attribute;
 
-        if (this.typeLabel !== attribute.getType().getLabel().scopedName()) return false;
+        if (this.typeLabel !== attribute.type.label.scopedName) return false;
 
         return this.check(attribute);
     }
@@ -237,7 +233,7 @@ class ThingKeyMatcher extends AttributeMatcher {
         const keys = await (concept as Thing).asRemote(tx()).getHas(true).collect();
 
         for (const key of keys) {
-            if (key.getType().getLabel().scopedName() === this.typeLabel) {
+            if (key.type.label.scopedName === this.typeLabel) {
                 return this.check(key);
             }
         }
@@ -364,7 +360,7 @@ Then("answer groups are", async (answerIdentifiersTable: DataTable) => {
         const identifier = parseConceptIdentifier(answerIdentifierGroup.ownerIdentifier);
         let answerGroup: ConceptMapGroup;
         for (const group of answerGroups) {
-            if (await identifier.matches(group.owner())) {
+            if (await identifier.matches(group.owner)) {
                 answerGroup = group;
                 break;
             }
@@ -372,7 +368,7 @@ Then("answer groups are", async (answerIdentifiersTable: DataTable) => {
         assert(answerGroup, `The group identifier [${JSON.stringify(answerIdentifierGroup.ownerIdentifier)}] does not match any of the answer group owners.`);
 
         const resultSet: [AnswerIdentifier, ConceptMap[]][] = answerIdentifierGroup.answerIdentifiers.map(ai => [ai, []]);
-        for (const answer0 of answerGroup.conceptMaps()) {
+        for (const answer0 of answerGroup.conceptMaps) {
             for (const [answerIdentifier, matchedAnswers] of resultSet) {
                 if (await answerConceptsMatch(answerIdentifier, answer0)) {
                     matchedAnswers.push(answer0);
@@ -400,15 +396,15 @@ Then("group aggregate values are", async (answerIdentifiersTable: DataTable) => 
         const identifier = parseConceptIdentifier(ownerIdentifier);
         let numericGroup;
         for (const group of numericAnswerGroups) {
-            if (await identifier.matches(group.owner())) {
+            if (await identifier.matches(group.owner)) {
                 numericGroup = group;
                 break;
             }
         }
         assert(numericGroup, `The group identifier [${JSON.stringify(ownerIdentifier)}] does not match any of the answer group owners.`);
 
-        const actualAnswer = getNumericValue(numericGroup.numeric());
-        assertNumericValue(numericGroup.numeric(), expectedAnswer,
+        const actualAnswer = getNumericValue(numericGroup.numeric);
+        assertNumericValue(numericGroup.numeric, expectedAnswer,
             `Expected answer [${expectedAnswer}] for group [${JSON.stringify(ownerIdentifier)}], but got [${actualAnswer}]`);
     }
 });
@@ -426,10 +422,10 @@ function applyQueryTemplate(template: string, answer: ConceptMap): string {
     while ((match = pattern.exec(template))) {
         const requiredVariable = variableFromTemplatePlaceholder(match[1]);
         query += template.substring(i, match.index);
-        if (answer.map().has(requiredVariable)) {
+        if (answer.map.has(requiredVariable)) {
             const concept = answer.get(requiredVariable);
             if (!concept.isThing()) throw new TypeError("Cannot apply IID templating to Types");
-            query += (concept as Thing).getIID();
+            query += (concept as Thing).iid;
         } else {
             throw new Error(`No IID available for template placeholder: [${match[0]}]`);
         }
@@ -442,13 +438,13 @@ function applyQueryTemplate(template: string, answer: ConceptMap): string {
 Then("each answer satisfies", async (template: string) => {
     for (const answer of answers) {
         const query = applyQueryTemplate(template, answer);
-        assert.strictEqual((await tx().query().match(query).collect()).length, 1);
+        assert.strictEqual((await tx().query.match(query).collect()).length, 1);
     }
 });
 
 Then("each answer does not satisfy", async (template: string) => {
     for (const answer of answers) {
         const query = applyQueryTemplate(template, answer);
-        assert.strictEqual((await tx().query().match(query).collect()).length, 0);
+        assert.strictEqual((await tx().query.match(query).collect()).length, 0);
     }
 });

--- a/test/deployment/application.test.js
+++ b/test/deployment/application.test.js
@@ -19,9 +19,7 @@
  * under the License.
  */
 
-const { TypeDB } = require("typedb-client/TypeDB");
-const { SessionType } = require("typedb-client/api/connection/TypeDBSession");
-const { TransactionType } = require("typedb-client/api/connection/TypeDBTransaction");
+const { TypeDB, SessionType, TransactionType } = require("typedb-client");
 
 jest.setTimeout(15000);
 
@@ -29,38 +27,37 @@ let client;
 
 beforeEach(async () => {
     client = TypeDB.coreClient();
-    await client.databases().create("thisisadatabase");
+    await client.databases.create("typedb");
 })
 
 afterEach(async () => {
-    const db = await client.databases().get("thisisadatabase");
+    const db = await client.databases.get("typedb");
     await db.delete();
     client.close();
 });
 
-
 describe("Basic TypeDBClient Tests", () => {
     test("define with concepts client", async () => {
-        let session = await client.session("thisisadatabase", SessionType.SCHEMA);
+        let session = await client.session("typedb", SessionType.SCHEMA);
         let tx = await session.transaction(TransactionType.WRITE);
-        await tx.concepts().putEntityType("lion");
+        await tx.concepts.putEntityType("lion");
         await tx.commit();
-        await session.close();
+        return await session.close();
     });
 
     test("define by running query", async () => {
-        let session = await client.session("thisisadatabase", SessionType.SCHEMA);
+        let session = await client.session("typedb", SessionType.SCHEMA);
         let tx = await session.transaction(TransactionType.WRITE);
-        await tx.query("define person sub entity, has name; name sub attribute, value string;");
+        await tx.query.match("define person sub entity, owns name; name sub attribute, value string;");
         await tx.commit();
-        await session.close();
+        return await session.close();
     });
 
     test("match", async () => {
-        let session = await client.session("thisisadatabase", SessionType.DATA);
+        let session = await client.session("typedb", SessionType.DATA);
         let tx = await session.transaction(TransactionType.WRITE);
-        await tx.query("match $x sub thing; get;");
+        await tx.query.match("match $x sub thing;");
         await tx.close();
-        await session.close();
+        return await session.close();
     });
 });

--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -1,0 +1,10 @@
+## TypeDB Client for Node.js: Integration Tests
+
+These JavaScript tests verify the correctness of connection, Concept and Query methods.
+
+The only prerequisite to run them locally is that you must have `npm` or `yarn` installed, and a TypeDB server running in the background.
+
+To run all tests, run:
+```
+npm test
+```

--- a/test/integration/test-cluster-failover.js
+++ b/test/integration/test-cluster-failover.js
@@ -19,10 +19,7 @@
  * under the License.
  */
 
-const { TypeDB} = require("../../dist/TypeDB");
-const {SessionType} = require("../../dist/api/connection/TypeDBSession")
-const {TransactionType} = require("../../dist/api/connection/TypeDBTransaction")
-const {TypeDBCredential} = require("../../dist/api/connection/TypeDBCredential")
+const { TypeDB, SessionType, TransactionType, TypeDBCredential } = require("../../dist");
 const { spawn, spawnSync } = require("child_process");
 const assert = require("assert");
 
@@ -54,25 +51,25 @@ async function run() {
         new TypeDBCredential("admin", "password", process.env.ROOT_CA)
     );
     try {
-        if (await client.databases().contains("typedb")) {
-            await (await client.databases().get("typedb")).delete();
+        if (await client.databases.contains("typedb")) {
+            await (await client.databases.get("typedb")).delete();
         }
-        await client.databases().create("typedb");
-        let primaryReplica = await seekPrimaryReplica(client.databases());
+        await client.databases.create("typedb");
+        let primaryReplica = await seekPrimaryReplica(client.databases);
         console.info(`Performing operations against the primary replica ${primaryReplica}`);
 
         let session = await client.session("typedb", SessionType.SCHEMA);
         let tx = await session.transaction(TransactionType.WRITE);
-        let person = await tx.concepts().putEntityType("person");
-        console.info(`Put the entity type '${person.getLabel().scopedName()}'.`);
+        let person = await tx.concepts.putEntityType("person");
+        console.info(`Put the entity type '${person.label.scopedName}'.`);
         await tx.commit();
         tx = await session.transaction(TransactionType.READ);
-        person = await tx.concepts().getEntityType("person");
-        console.info(`Retrieved entity type with label '${person.getLabel().scopedName()}' from primary replica.`);
+        person = await tx.concepts.getEntityType("person");
+        console.info(`Retrieved entity type with label '${person.label.scopedName}' from primary replica.`);
         await session.close();
 
         for (let iteration = 1; iteration <= 10; iteration++) {
-            primaryReplica = await seekPrimaryReplica(client.databases());
+            primaryReplica = await seekPrimaryReplica(client.databases);
             console.info(`Stopping primary replica (test ${iteration}/10)...`);
             const port = primaryReplica.address().substring(10,15);
             const primaryReplicaServerPID = getServerPID(port);
@@ -82,9 +79,9 @@ async function run() {
             await new Promise(resolve => setTimeout(resolve, 1000));
             session = await client.session("typedb", SessionType.SCHEMA);
             tx = await session.transaction(TransactionType.READ);
-            person = await tx.concepts().putEntityType("person");
-            console.info(`Retrieved entity type with label '${person.getLabel().scopedName()}' from new primary replica`);
-            assert(person.getLabel().scopedName() === "person");
+            person = await tx.concepts.putEntityType("person");
+            console.info(`Retrieved entity type with label '${person.label.scopedName}' from new primary replica`);
+            assert(person.label.scopedName === "person");
             const idx = primaryReplica.address()[10];
             spawn(`./${idx}/typedb`, ["cluster", "--data", "server/data", "--address", `127.0.0.1:${idx}1729:${idx}1730:${idx}1731`,
                 "--peer", "127.0.0.1:11729:11730:11731", "--peer", "127.0.0.1:21729:21730:21731", "--peer", "127.0.0.1:31729:31730:31731", "--encryption-enabled=true"]);

--- a/test/integration/test-cluster-failover.js
+++ b/test/integration/test-cluster-failover.js
@@ -27,8 +27,8 @@ async function seekPrimaryReplica(databases) {
     for (let retryNum = 0; retryNum < 10; retryNum++) {
         console.info("Discovering replicas for database 'typedb'...");
         const db = await databases.get("typedb");
-        console.info(`Discovered ${db.replicas()}`);
-        if (db.primaryReplica()) return db.primaryReplica();
+        console.info(`Discovered ${db.replicas}`);
+        if (db.primaryReplica) return db.primaryReplica;
         retryNum++;
         console.info("There is no primary replica yet. Retrying in 2s...");
         await new Promise(resolve => setTimeout(resolve, 2000));
@@ -71,7 +71,7 @@ async function run() {
         for (let iteration = 1; iteration <= 10; iteration++) {
             primaryReplica = await seekPrimaryReplica(client.databases);
             console.info(`Stopping primary replica (test ${iteration}/10)...`);
-            const port = primaryReplica.address().substring(10,15);
+            const port = primaryReplica.address.substring(10,15);
             const primaryReplicaServerPID = getServerPID(port);
             console.info(`Primary replica is hosted by server with PID ${primaryReplicaServerPID}`);
             spawnSync("kill", ["-9", primaryReplicaServerPID]);
@@ -82,7 +82,7 @@ async function run() {
             person = await tx.concepts.putEntityType("person");
             console.info(`Retrieved entity type with label '${person.label.scopedName}' from new primary replica`);
             assert(person.label.scopedName === "person");
-            const idx = primaryReplica.address()[10];
+            const idx = primaryReplica.address[10];
             spawn(`./${idx}/typedb`, ["cluster", "--data", "server/data", "--address", `127.0.0.1:${idx}1729:${idx}1730:${idx}1731`,
                 "--peer", "127.0.0.1:11729:11730:11731", "--peer", "127.0.0.1:21729:21730:21731", "--peer", "127.0.0.1:31729:31730:31731", "--encryption-enabled=true"]);
             await new Promise(resolve => setTimeout(resolve, 20000));

--- a/test/integration/test-concept.js
+++ b/test/integration/test-concept.js
@@ -269,7 +269,7 @@ async function run() {
 
     try {
         tx = await session.transaction(TransactionType.WRITE);
-        await tx.logic().putRule("septuagenarian-rule", "{$x isa person;}", "$x has age 70");
+        await tx.logic.putRule("septuagenarian-rule", "{$x isa person;}", "$x has age 70");
         await tx.commit();
         await tx.close();
         console.log(`put rule - SUCCESS`);

--- a/test/integration/test-concept.js
+++ b/test/integration/test-concept.js
@@ -19,24 +19,21 @@
  * under the License.
  */
 
-const {TypeDB} = require("../../dist/TypeDB");
-const {SessionType} = require("../../dist/api/connection/TypeDBSession")
-const {TransactionType} = require("../../dist/api/connection/TypeDBTransaction")
-const {AttributeType} = require("../../dist/api/concept/type/AttributeType");
+const { TypeDB, SessionType, TransactionType, AttributeType } = require("../../dist");
 const assert = require("assert");
 
 async function run() {
     const client = TypeDB.coreClient();
 
     try {
-        const dbs = await client.databases().all();
+        const dbs = await client.databases.all();
         console.log(`get databases - SUCCESS - the databases are [${dbs}]`);
-        const typedb = dbs.find(x => x.name() === "typedb");
+        const typedb = dbs.find(x => x.name === "typedb");
         if (typedb) {
             await typedb.delete();
             console.log(`delete database - SUCCESS - 'typedb' has been deleted`);
         }
-        await client.databases().create("typedb");
+        await client.databases.create("typedb");
         console.log("create database - SUCCESS - 'typedb' has been created");
     } catch (err) {
         console.error(`database operations - ERROR: ${err.stack || err}`);
@@ -53,7 +50,7 @@ async function run() {
     try {
         session = await client.session("typedb", SessionType.SCHEMA);
         tx = await session.transaction(TransactionType.WRITE);
-        lion = await tx.concepts().putEntityType("lion");
+        lion = await tx.concepts.putEntityType("lion");
         await tx.commit();
         await tx.close();
         console.log("putEntityType - SUCCESS");
@@ -65,7 +62,7 @@ async function run() {
 
     try {
         tx = await session.transaction(TransactionType.WRITE);
-        lionFamily = await tx.concepts().putRelationType("lion-family");
+        lionFamily = await tx.concepts.putRelationType("lion-family");
         await lionFamily.asRemote(tx).setRelates("lion-cub");
         lionCub = await lionFamily.asRemote(tx).getRelates().collect().then(roles => roles[0]);
         await lion.asRemote(tx).setPlays(lionCub);
@@ -80,7 +77,7 @@ async function run() {
 
     try {
         tx = await session.transaction(TransactionType.WRITE);
-        maneSize = await tx.concepts().putAttributeType("mane-size", AttributeType.ValueType.LONG);
+        maneSize = await tx.concepts.putAttributeType("mane-size", AttributeType.ValueType.LONG);
         await lion.asRemote(tx).setOwns(maneSize);
         await tx.commit();
         await tx.close();
@@ -94,7 +91,7 @@ async function run() {
     let stoneLion;
     try {
         tx = await session.transaction(TransactionType.WRITE);
-        stoneLion = await tx.concepts().putEntityType("stone-lion");
+        stoneLion = await tx.concepts.putEntityType("stone-lion");
         await stoneLion.asRemote(tx).setSupertype(lion);
         await tx.commit();
         await tx.close();
@@ -109,7 +106,7 @@ async function run() {
         tx = await session.transaction(TransactionType.READ);
         const supertypeOfLion = await lion.asRemote(tx).getSupertype();
         await tx.close();
-        console.log(`get supertype - SUCCESS - the supertype of 'lion' is '${supertypeOfLion.getLabel()}'.`);
+        console.log(`get supertype - SUCCESS - the supertype of 'lion' is '${supertypeOfLion.label}'.`);
     } catch (err) {
         console.error(`get supertype - ERROR: ${err.stack || err}`);
         client.close();
@@ -120,7 +117,7 @@ async function run() {
         tx = await session.transaction(TransactionType.READ);
         const supertypesOfStoneLion = await stoneLion.asRemote(tx).getSupertypes().collect();
         await tx.close();
-        console.log(`get supertypes - SUCCESS - the supertypes of 'stone-lion' are [${supertypesOfStoneLion.map(x => x.getLabel())}].`);
+        console.log(`get supertypes - SUCCESS - the supertypes of 'stone-lion' are [${supertypesOfStoneLion.map(x => x.label)}].`);
     } catch (err) {
         console.error(`get supertypes - ERROR: ${err.stack || err}`);
         client.close();
@@ -131,7 +128,7 @@ async function run() {
         tx = await session.transaction(TransactionType.READ);
         const subtypesOfLion = await lion.asRemote(tx).getSubtypes().collect();
         await tx.close();
-        console.log(`get subtypes - SUCCESS - the subtypes of 'lion' are [${subtypesOfLion.map(x => x.getLabel())}].`);
+        console.log(`get subtypes - SUCCESS - the subtypes of 'lion' are [${subtypesOfLion.map(x => x.label)}].`);
     } catch (err) {
         console.error(`get subtypes - ERROR: ${err.stack || err}`);
         client.close();
@@ -140,9 +137,9 @@ async function run() {
 
     try {
         tx = await session.transaction(TransactionType.WRITE);
-        const monkey = await tx.concepts().putEntityType("monkey");
+        const monkey = await tx.concepts.putEntityType("monkey");
         await monkey.asRemote(tx).setLabel("orangutan");
-        const newLabel = await tx.concepts().getEntityType("orangutan").then(entityType => entityType.getLabel().scopedName());
+        const newLabel = await tx.concepts.getEntityType("orangutan").then(entityType => entityType.label.scopedName);
         await tx.rollback();
         await tx.close();
         assert(newLabel === "orangutan");
@@ -155,7 +152,7 @@ async function run() {
 
     try {
         tx = await session.transaction(TransactionType.WRITE);
-        const whale = await tx.concepts().putEntityType("whale");
+        const whale = await tx.concepts.putEntityType("whale");
         await whale.asRemote(tx).setAbstract();
         const isAbstractAfterSet = await whale.asRemote(tx).isAbstract();
         assert(isAbstractAfterSet);
@@ -175,20 +172,20 @@ async function run() {
     let parentship, fathership, person, man, parent, father;
     try {
         tx = await session.transaction(TransactionType.WRITE);
-        parentship = await tx.concepts().putRelationType("parentship");
+        parentship = await tx.concepts.putRelationType("parentship");
         await parentship.asRemote(tx).setRelates("parent");
-        fathership = await tx.concepts().putRelationType("fathership");
+        fathership = await tx.concepts.putRelationType("fathership");
         await fathership.asRemote(tx).setSupertype(parentship);
         await fathership.asRemote(tx).setRelates("father", "parent");
-        person = await tx.concepts().putEntityType("person");
+        person = await tx.concepts.putEntityType("person");
         parent = await parentship.asRemote(tx).getRelates("parent");
         await person.asRemote(tx).setPlays(parent);
-        man = await tx.concepts().putEntityType("man");
+        man = await tx.concepts.putEntityType("man");
         await man.asRemote(tx).setSupertype(person);
         father = await fathership.asRemote(tx).getRelates("father");
         await man.asRemote(tx).setPlays(father, parent);
-        const playingRoles = (await man.asRemote(tx).getPlays().collect()).map(role => role.getLabel().scopedName());
-        const roleplayers = (await father.asRemote(tx).getPlayers().collect()).map(player => player.getLabel().scopedName());
+        const playingRoles = (await man.asRemote(tx).getPlays().collect()).map(role => role.label.scopedName);
+        const roleplayers = (await father.asRemote(tx).getPlayers().collect()).map(player => player.label.scopedName);
         await tx.commit();
         await tx.close();
         assert(playingRoles.includes("fathership:father"));
@@ -203,16 +200,16 @@ async function run() {
     let email, workEmail, customer, age;
     try {
         tx = await session.transaction(TransactionType.WRITE);
-        email = await tx.concepts().putAttributeType("email", AttributeType.ValueType.STRING);
+        email = await tx.concepts.putAttributeType("email", AttributeType.ValueType.STRING);
         await email.asRemote(tx).setAbstract();
-        workEmail = await tx.concepts().putAttributeType("work-email", AttributeType.ValueType.STRING);
+        workEmail = await tx.concepts.putAttributeType("work-email", AttributeType.ValueType.STRING);
         await workEmail.asRemote(tx).setSupertype(email);
-        age = await tx.concepts().putAttributeType("age", AttributeType.ValueType.LONG);
+        age = await tx.concepts.putAttributeType("age", AttributeType.ValueType.LONG);
         await person.asRemote(tx).setAbstract();
         await person.asRemote(tx).setOwns(email, true);
         await person.asRemote(tx).setOwns(age, false);
         await lion.asRemote(tx).setOwns(age);
-        customer = await tx.concepts().putEntityType("customer");
+        customer = await tx.concepts.putEntityType("customer");
         await customer.asRemote(tx).setSupertype(person);
         await customer.asRemote(tx).setOwns(workEmail, email, true);
         const ownedAttributes = await customer.asRemote(tx).getOwns().collect();
@@ -223,8 +220,8 @@ async function run() {
         assert(ownedAttributes.length === 2);
         assert(ownedKeys.length === 1);
         assert(ownedDateTimes.length === 0);
-        console.log(`get/set owns, overriding a super-attribute - SUCCESS - 'customer' owns [${ownedAttributes.map(x => x.getLabel().scopedName())}], ` +
-            `of which [${ownedKeys.map(x => x.getLabel().scopedName())}] are keys, and [${ownedDateTimes.map((x => x.getLabel()))}] are datetimes`);
+        console.log(`get/set owns, overriding a super-attribute - SUCCESS - 'customer' owns [${ownedAttributes.map(x => x.label.scopedName)}], ` +
+            `of which [${ownedKeys.map(x => x.label.scopedName)}] are keys, and [${ownedDateTimes.map((x => x.label))}] are datetimes`);
     } catch (err) {
         console.error(`get/set owns, overriding a super-attribute - ERROR: ${err.stack || err}`);
         client.close();
@@ -236,9 +233,9 @@ async function run() {
         await person.asRemote(tx).unsetOwns(age);
         await person.asRemote(tx).unsetPlays(parent);
         await fathership.asRemote(tx).unsetRelates("father");
-        const personOwns = (await person.asRemote(tx).getOwns().collect()).map(x => x.getLabel().scopedName());
-        const personPlays = (await person.asRemote(tx).getPlays().collect()).map(x => x.getLabel().scopedName());
-        const fathershipRelates = (await fathership.asRemote(tx).getRelates().collect()).map(x => x.getLabel().scopedName());
+        const personOwns = (await person.asRemote(tx).getOwns().collect()).map(x => x.label.scopedName);
+        const personPlays = (await person.asRemote(tx).getPlays().collect()).map(x => x.label.scopedName);
+        const fathershipRelates = (await fathership.asRemote(tx).getRelates().collect()).map(x => x.label.scopedName);
         await tx.rollback();
         await tx.close();
         assert(!personOwns.includes("age"));
@@ -255,15 +252,15 @@ async function run() {
     let password, shoeSize, volume, isAlive, startDate;
     try {
         tx = await session.transaction(TransactionType.WRITE);
-        password = await tx.concepts().putAttributeType("password", AttributeType.ValueType.STRING);
-        shoeSize = await tx.concepts().putAttributeType("shoe-size", AttributeType.ValueType.LONG);
-        volume = await tx.concepts().putAttributeType("volume", AttributeType.ValueType.DOUBLE);
-        isAlive = await tx.concepts().putAttributeType("is-alive", AttributeType.ValueType.BOOLEAN);
-        startDate = await tx.concepts().putAttributeType("start-date", AttributeType.ValueType.DATETIME);
+        password = await tx.concepts.putAttributeType("password", AttributeType.ValueType.STRING);
+        shoeSize = await tx.concepts.putAttributeType("shoe-size", AttributeType.ValueType.LONG);
+        volume = await tx.concepts.putAttributeType("volume", AttributeType.ValueType.DOUBLE);
+        isAlive = await tx.concepts.putAttributeType("is-alive", AttributeType.ValueType.BOOLEAN);
+        startDate = await tx.concepts.putAttributeType("start-date", AttributeType.ValueType.DATETIME);
         await tx.commit();
         await tx.close();
-        console.log(`put all 5 attribute value types - SUCCESS - password is a ${password.getValueType()}, shoe-size is a ${shoeSize.getValueType()}, `
-            + `volume is a ${volume.getValueType()}, is-alive is a ${isAlive.getValueType()} and start-date is a ${startDate.getValueType()}`);
+        console.log(`put all 5 attribute value types - SUCCESS - password is a ${password.valueType}, shoe-size is a ${shoeSize.valueType}, `
+            + `volume is a ${volume.valueType}, is-alive is a ${isAlive.valueType} and start-date is a ${startDate.valueType}`);
     } catch (err) {
         console.error(`put all 5 attribute value types - ERROR: ${err.stack || err}`);
         client.close();
@@ -301,21 +298,21 @@ async function run() {
         for (let i = 0; i < 10; i++)  stoneLion.asRemote(tx).create();
         const lions = await lion.asRemote(tx).getInstances().collect();
         const firstLion = lions[0];
-        const isInferred = firstLion.isInferred();
-        const lionType = await firstLion.asRemote(tx).getType();
+        const inferred = firstLion.inferred;
+        const lionType = await firstLion.asRemote(tx).type;
         const age42 = await age.asRemote(tx).put(42);
         await firstLion.asRemote(tx).setHas(age42);
-        const firstLionAttrs = (await firstLion.asRemote(tx).getHas().collect()).map(x => x.getValue());
+        const firstLionAttrs = (await firstLion.asRemote(tx).getHas().collect()).map(x => x.value);
         assert(firstLionAttrs.length === 1);
         assert(firstLionAttrs[0] === 42);
-        const firstLionAges = (await firstLion.asRemote(tx).getHas(age).collect()).map(x => x.getValue());
+        const firstLionAges = (await firstLion.asRemote(tx).getHas(age).collect()).map(x => x.value);
         assert(firstLionAges.length === 1)
         assert(firstLionAges[0] === 42);
-        const firstLionWorkEmails = (await firstLion.asRemote(tx).getHas(workEmail).collect()).map(x => x.getValue());
+        const firstLionWorkEmails = (await firstLion.asRemote(tx).getHas(workEmail).collect()).map(x => x.value);
         assert(!firstLionWorkEmails.length);
         const firstFamily = await lionFamily.asRemote(tx).create();
         await firstFamily.asRemote(tx).addPlayer(lionCub, firstLion);
-        const firstLionPlaying = (await firstLion.asRemote(tx).getPlaying().collect()).map(x => x.getLabel().scopedName());
+        const firstLionPlaying = (await firstLion.asRemote(tx).getPlaying().collect()).map(x => x.label.scopedName);
         assert(firstLionPlaying.length === 1);
         assert(firstLionPlaying[0] === "lion-family:lion-cub");
         const firstLionRelations = await firstLion.asRemote(tx).getRelations().collect();
@@ -325,9 +322,9 @@ async function run() {
         await tx.commit();
         await tx.close();
         assert(lions.length === 10);
-        assert(!isInferred);
+        assert(!inferred);
         console.log(`Thing methods - SUCCESS - There are ${lions.length} lions.`);
-        assert(lionType.getLabel().scopedName() === "stone-lion");
+        assert(lionType.label.scopedName === "stone-lion");
         console.log(`getType - SUCCESS - After looking more closely, it turns out that there are ${lions.length} stone lions.`);
     } catch (err) {
         console.error(`Thing methods - ERROR: ${err.stack || err}`);
@@ -347,7 +344,7 @@ async function run() {
         assert(lionCubPlayers.length === 1);
         const playersByRoleType = (await firstLionFamily.asRemote(tx).getPlayersByRoleType()).keys();
         const firstPlayer = playersByRoleType.next().value;
-        assert(firstPlayer.getLabel().scopedName() === "lion-family:lion-cub");
+        assert(firstPlayer.label.scopedName === "lion-family:lion-cub");
         await firstLionFamily.asRemote(tx).removePlayer(lionCub, firstLion);
         const lionFamilyCleanedUp = await firstLionFamily.asRemote(tx).isDeleted();
         assert(lionFamilyCleanedUp);
@@ -369,8 +366,8 @@ async function run() {
         const startDateAttr = await startDate.asRemote(tx).put(new Date());
         await tx.commit();
         await tx.close();
-        console.log(`put 5 different types of attributes - SUCCESS - password is ${passwordAttr.getValue()}, shoe-size is ${shoeSizeAttr.getValue()}, `
-            + `volume is ${volumeAttr.getValue()}, is-alive is ${isAliveAttr.getValue()} and start-date is ${startDateAttr.getValue()}`);
+        console.log(`put 5 different types of attributes - SUCCESS - password is ${passwordAttr.value}, shoe-size is ${shoeSizeAttr.value}, `
+            + `volume is ${volumeAttr.value}, is-alive is ${isAliveAttr.value} and start-date is ${startDateAttr.value}`);
     } catch (err) {
         console.error(`put 5 different types of attributes - ERROR: ${err.stack || err}`);
         client.close();

--- a/test/integration/test-connection.js
+++ b/test/integration/test-connection.js
@@ -19,22 +19,20 @@
  * under the License.
  */
 
-const {TypeDB} = require("../../dist/TypeDB");
-const {SessionType} = require("../../dist/api/connection/TypeDBSession")
-const {TransactionType} = require("../../dist/api/connection/TypeDBTransaction")
+const { TypeDB, SessionType, TransactionType } = require("../../dist");
 
 async function run() {
     const client = TypeDB.coreClient();
 
     try {
-        const dbs = await client.databases().all();
+        const dbs = await client.databases.all();
         console.log(`get databases - SUCCESS - the databases are [${dbs}]`);
-        const typedb = dbs.find(x => x.name() === "typedb");
+        const typedb = dbs.find(x => x.name === "typedb");
         if (typedb) {
             await typedb.delete();
             console.log(`delete database - SUCCESS - 'typedb' has been deleted`);
         }
-        await client.databases().create("typedb");
+        await client.databases.create("typedb");
         console.log("create database - SUCCESS - 'typedb' has been created");
     } catch (err) {
         console.error(`database operations - ERROR: ${err.stack || err}`);

--- a/test/integration/test-query.js
+++ b/test/integration/test-query.js
@@ -53,10 +53,10 @@ async function run() {
     }
 
     try {
-        await tx.query().define("define name sub attribute, value string;")
-        await tx.query().define("define rank sub attribute, value string;")
-        await tx.query().define("define inferred-age sub attribute, value long;")
-        await tx.query().define("define power-level sub attribute, value double;")
+        await tx.query.define("define name sub attribute, value string;")
+        await tx.query.define("define rank sub attribute, value string;")
+        await tx.query.define("define inferred-age sub attribute, value long;")
+        await tx.query.define("define power-level sub attribute, value double;")
         console.log("define attributes query - SUCCESS");
     } catch (err) {
         console.error(`define attributes query - ERROR: ${err.stack || err}`);
@@ -84,7 +84,7 @@ async function run() {
 
     try {
         tx = await session.transaction(TransactionType.WRITE);
-        await tx.query().define("define lionfight sub relation, relates victor, relates loser;")
+        await tx.query.define("define lionfight sub relation, relates victor, relates loser;")
         await tx.commit();
         await tx.close();
         console.log("define relationship query - SUCCESS");
@@ -96,7 +96,7 @@ async function run() {
 
     try {
         tx = await session.transaction(TransactionType.WRITE);
-        await tx.query().define("define lion sub entity, owns name, owns rank, owns power-level, owns inferred-age, plays lionfight:victor, plays lionfight:loser;")
+        await tx.query.define("define lion sub entity, owns name, owns rank, owns power-level, owns inferred-age, plays lionfight:victor, plays lionfight:loser;")
         await tx.commit();
         await tx.close();
         console.log("define entity query - SUCCESS");
@@ -108,7 +108,7 @@ async function run() {
 
     try {
         tx = await session.transaction(TransactionType.WRITE);
-        await tx.query().define("define rule lions-have-age: when { $x isa lion;} then { $x has inferred-age 10; };");
+        await tx.query.define("define rule lions-have-age: when { $x isa lion;} then { $x has inferred-age 10; };");
         await tx.commit();
         await tx.close();
         console.log("define rule query - SUCCESS");
@@ -120,8 +120,8 @@ async function run() {
 
     try {
         tx = await session.transaction(TransactionType.WRITE);
-        await tx.query().define("define giraffe sub entity, owns name, plays lionfight:victor;")
-        await tx.query().undefine("undefine giraffe plays lionfight:victor;")
+        await tx.query.define("define giraffe sub entity, owns name, plays lionfight:victor;")
+        await tx.query.undefine("undefine giraffe plays lionfight:victor;")
         await tx.commit();
         await tx.close();
         console.log("define/undefine entity query - SUCCESS");
@@ -160,13 +160,13 @@ async function run() {
     }
 
     try {
-        let firstLionStream = await tx.query().insert("insert $x isa lion, has name \"Steve\", has rank \"Duke\", has power-level 12;");
+        let firstLionStream = await tx.query.insert("insert $x isa lion, has name \"Steve\", has rank \"Duke\", has power-level 12;");
         let lionCollection = await firstLionStream.collect()
         assert(lionCollection.length === 1);
-        await tx.query().insert("insert $x isa lion, has name \"Chandra\", has rank \"Baron\", has power-level 7;");
-        await tx.query().insert("insert $x isa lion, has name \"Asuka\", has rank \"Duchess\", has power-level 3;");
-        await tx.query().insert("insert $x isa lion, has name \"Sergey\", has rank \"Lowborn\", has power-level 13;");
-        await tx.query().insert("insert $x isa lion, has name \"Amélie\", has rank \"Marchioness\", has power-level 20;");
+        await tx.query.insert("insert $x isa lion, has name \"Chandra\", has rank \"Baron\", has power-level 7;");
+        await tx.query.insert("insert $x isa lion, has name \"Asuka\", has rank \"Duchess\", has power-level 3;");
+        await tx.query.insert("insert $x isa lion, has name \"Sergey\", has rank \"Lowborn\", has power-level 13;");
+        await tx.query.insert("insert $x isa lion, has name \"Amélie\", has rank \"Marchioness\", has power-level 20;");
         let lionType = await tx.concepts.getEntityType("lion");
         let nameType = await tx.concepts.getAttributeType("name");
         let lionNames = [];
@@ -178,7 +178,7 @@ async function run() {
         // await tx.commit();
         // await tx.close();
         // tx = await session.transaction(TransactionType.WRITE);
-        // const matchresult = await tx.query().match("match $x isa lion, has name $y, has rank $z;");
+        // const matchresult = await tx.query.match("match $x isa lion, has name $y, has rank $z;");
         // for await (const match of matchresult) {
         //     console.log(match);
         // }
@@ -201,12 +201,12 @@ async function run() {
 
     try {
         tx = await session.transaction(TransactionType.READ, TypeDBOptions.core({infer: true, explain: true}));
-        const answers = await tx.query().match("match $x has inferred-age $a;").collect();
+        const answers = await tx.query.match("match $x has inferred-age $a;").collect();
         const ans = answers[0];
-        assert(ans.explainables().ownerships().size > 0);
-        const firstExplanations = await tx.query().explain(ans.explainables().ownerships().values().next().value).collect();
+        assert(ans.explainables.ownerships.size > 0);
+        const firstExplanations = await tx.query.explain(ans.explainables.ownerships.values().next().value).collect();
         assert(firstExplanations.length === 1);
-        const exactExplanations = await tx.query().explain(ans.explainables().ownership("x", "a")).collect();
+        const exactExplanations = await tx.query.explain(ans.explainables.ownership("x", "a")).collect();
         assert(exactExplanations.length === 1);
         console.log("open data read transaction - SUCCESS");
     } catch (err) {

--- a/test/integration/test-query.js
+++ b/test/integration/test-query.js
@@ -19,23 +19,20 @@
  * under the License.
  */
 
-const {TypeDB} = require("../../dist/TypeDB");
-const {SessionType} = require("../../dist/api/connection/TypeDBSession")
-const {TransactionType} = require("../../dist/api/connection/TypeDBTransaction")
-const {TypeDBOptions} = require("../../dist/api/connection/TypeDBOptions");
+const { TypeDB, SessionType, TransactionType, TypeDBOptions } = require("../../dist");
 const assert = require("assert");
 
 async function run() {
     const client = TypeDB.coreClient();
     try {
-        const dbs = await client.databases().all();
+        const dbs = await client.databases.all();
         console.log(`get databases - SUCCESS - the databases are [${dbs}]`);
-        const typedb = dbs.find(x => x.name() === "typedb");
+        const typedb = dbs.find(x => x.name === "typedb");
         if (typedb) {
             await typedb.delete();
             console.log(`delete database - SUCCESS - 'typedb' has been deleted`);
         }
-        await client.databases().create("typedb");
+        await client.databases.create("typedb");
         console.log("create database - SUCCESS - 'typedb' has been created");
     } catch (err) {
         console.error(`database operations - ERROR: ${err.stack || err}`);
@@ -170,12 +167,12 @@ async function run() {
         await tx.query().insert("insert $x isa lion, has name \"Asuka\", has rank \"Duchess\", has power-level 3;");
         await tx.query().insert("insert $x isa lion, has name \"Sergey\", has rank \"Lowborn\", has power-level 13;");
         await tx.query().insert("insert $x isa lion, has name \"Amélie\", has rank \"Marchioness\", has power-level 20;");
-        let lionType = await tx.concepts().getEntityType("lion");
-        let nameType = await tx.concepts().getAttributeType("name");
+        let lionType = await tx.concepts.getEntityType("lion");
+        let nameType = await tx.concepts.getAttributeType("name");
         let lionNames = [];
         for await (let lion of lionType.asRemote(tx).getInstances()) {
             for await (let lionName of lion.asRemote(tx).getHas(nameType)) {
-                lionNames.push(lionName.getValue());
+                lionNames.push(lionName.value);
             }
         }
         // await tx.commit();


### PR DESCRIPTION
## What is the goal of this PR?

Because client-nodejs is based on Client Java, we were using methods in a lot of places where a property would be more fitting. So, for example, we've changed `Concept.getType()` to just `Concept.type`, and `Type.getLabel()` to just `Type.label`.

## What are the changes implemented in this PR?

Replace methods with properties where appropriate