### PR TITLE
Use "asX" methods instead of type casts

### DIFF
--- a/concept/ConceptManagerImpl.ts
+++ b/concept/ConceptManagerImpl.ts
@@ -67,19 +67,19 @@ export class ConceptManagerImpl implements ConceptManager {
 
     async getEntityType(label: string): Promise<EntityType> {
         const type = await this.getThingType(label);
-        if (type && type.isEntityType()) return type as EntityType;
+        if (type?.isEntityType()) return type.asEntityType();
         else return null;
     }
 
     async getRelationType(label: string): Promise<RelationType> {
         const type = await this.getThingType(label);
-        if (type && type.isRelationType()) return type as RelationType;
+        if (type?.isRelationType()) return type.asRelationType();
         else return null;
     }
 
-    async getAttributeType(label: string): Promise<AttributeType | null> {
+    async getAttributeType(label: string): Promise<AttributeType> {
         const type = await this.getThingType(label);
-        if (type && type.isAttributeType()) return type as AttributeType;
+        if (type?.isAttributeType()) return type.asAttributeType();
         else return null;
     }
 

--- a/concept/answer/ConceptMapGroupImpl.ts
+++ b/concept/answer/ConceptMapGroupImpl.ts
@@ -52,6 +52,6 @@ export namespace ConceptMapGroupImpl {
         if (mapGroupProto.getOwner().hasThing()) owner = ThingImpl.of(mapGroupProto.getOwner().getThing());
         else owner = TypeImpl.of(mapGroupProto.getOwner().getType());
         return new ConceptMapGroupImpl(owner, mapGroupProto.getConceptMapsList()
-            .map((conceptMapProto) => ConceptMapImpl.of(conceptMapProto)) as ConceptMap[]);
+            .map((conceptMapProto) => ConceptMapImpl.of(conceptMapProto)));
     }
 }

--- a/concept/type/TypeImpl.ts
+++ b/concept/type/TypeImpl.ts
@@ -114,7 +114,7 @@ export namespace TypeImpl {
 
         equals(concept: Concept): boolean {
             if (!concept.isType()) return false;
-            return (concept as Type).label.equals(this.label);
+            return concept.asType().label.equals(this.label);
         }
 
         toString(): string {

--- a/test/behaviour/concept/thing/ThingSteps.ts
+++ b/test/behaviour/concept/thing/ThingSteps.ts
@@ -53,15 +53,15 @@ When("delete entity:/attribute:/relation: {var}", async (thingName: string) => {
 });
 
 When("entity/attribute/relation {var} set has: {var}", async (thingName: string, attributeName: string) => {
-    await get(thingName).asRemote(tx()).setHas(get(attributeName) as Attribute);
+    await get(thingName).asRemote(tx()).setHas(get(attributeName).asAttribute());
 });
 
 When("entity/attribute/relation {var} set has: {var}; throws exception", async (thingName: string, attributeName: string) => {
-    await assertThrows(async () => get(thingName).asRemote(tx()).setHas(get(attributeName) as Attribute));
+    await assertThrows(async () => get(thingName).asRemote(tx()).setHas(get(attributeName).asAttribute()));
 });
 
 When("entity/attribute/relation {var} unset has: {var}", async (thingName: string, attributeName: string) => {
-    await get(thingName).asRemote(tx()).unsetHas(get(attributeName) as Attribute);
+    await get(thingName).asRemote(tx()).unsetHas(get(attributeName).asAttribute());
 });
 
 When("entity/attribute/relation {var} get keys contain: {var}", async (thingName: string, attributeName: string) => {

--- a/test/behaviour/concept/thing/attribute/AttributeSteps.ts
+++ b/test/behaviour/concept/thing/attribute/AttributeSteps.ts
@@ -32,93 +32,93 @@ When("attribute\\({type_label}) get instances contain: {var}", async (typeLabel:
 });
 
 When("attribute {var} get owners contain: {var}", async (var1: string, var2: string) => {
-    assert(await (get(var1) as Attribute).asRemote(tx()).getOwners().some(x => x.equals(get(var2))));
+    assert(await get(var1).asAttribute().asRemote(tx()).getOwners().some(x => x.equals(get(var2))));
 });
 
 When("attribute {var} get owners do not contain: {var}", async (var1: string, var2: string) => {
-    assert(!(await (get(var1) as Attribute).asRemote(tx()).getOwners().some(x => x.equals(get(var2)))));
+    assert(!(await get(var1).asAttribute().asRemote(tx()).getOwners().some(x => x.equals(get(var2)))));
 });
 
 When("attribute {var} has value type: {value_type}", async (var0: string, valueType: ValueType) => {
-    assert.strictEqual(valueType, (get(var0) as Attribute).type.valueType);
+    assert.strictEqual(valueType, get(var0).asAttribute().type.valueType);
 });
 
 When("{var} = attribute\\({type_label}) as\\(boolean) put: {bool}", async (var0: string, typeLabel: string, value: boolean) => {
-    put(var0, await ((await tx().concepts.getAttributeType(typeLabel)) as AttributeType.Boolean).asRemote(tx()).put(value))
+    put(var0, await (await tx().concepts.getAttributeType(typeLabel)).asBoolean().asRemote(tx()).put(value));
 });
 
 When("attribute\\({type_label}) as\\(boolean) put: {bool}; throws exception", async (typeLabel: string, value: boolean) => {
-    await assertThrows(async () => await ((await tx().concepts.getAttributeType(typeLabel)) as AttributeType.Boolean).asRemote(tx()).put(value))
+    await assertThrows(async () => await (await tx().concepts.getAttributeType(typeLabel)).asBoolean().asRemote(tx()).put(value));
 });
 
 When("{var} = attribute\\({type_label}) as\\(long) put: {int}", async (var0: string, typeLabel: string, value: number) => {
-    put(var0, await ((await tx().concepts.getAttributeType(typeLabel)) as AttributeType.Long).asRemote(tx()).put(value))
+    put(var0, await (await tx().concepts.getAttributeType(typeLabel)).asLong().asRemote(tx()).put(value));
 });
 
 When("attribute\\({type_label}) as\\(long) put: {int}; throws exception", async (typeLabel: string, value: number) => {
-    await assertThrows(async () => await ((await tx().concepts.getAttributeType(typeLabel)) as AttributeType.Long).asRemote(tx()).put(value))
+    await assertThrows(async () => await (await tx().concepts.getAttributeType(typeLabel)).asLong().asRemote(tx()).put(value));
 });
 
 When("{var} = attribute\\({type_label}) as\\(double) put: {float}", async (var0: string, typeLabel: string, value: number) => {
-    put(var0, await ((await tx().concepts.getAttributeType(typeLabel)) as AttributeType.Double).asRemote(tx()).put(value))
+    put(var0, await (await tx().concepts.getAttributeType(typeLabel)).asDouble().asRemote(tx()).put(value));
 });
 
 When("attribute\\({type_label}) as\\(double) put: {float}; throws exception", async (typeLabel: string, value: number) => {
-    await assertThrows(async () => await ((await tx().concepts.getAttributeType(typeLabel)) as AttributeType.Double).asRemote(tx()).put(value))
+    await assertThrows(async () => await (await tx().concepts.getAttributeType(typeLabel)).asDouble().asRemote(tx()).put(value));
 });
 
 When("{var} = attribute\\({type_label}) as\\(string) put: {word}", async (var0: string, typeLabel: string, value: string) => {
-    put(var0, await ((await tx().concepts.getAttributeType(typeLabel)) as AttributeType.String).asRemote(tx()).put(value))
+    put(var0, await (await tx().concepts.getAttributeType(typeLabel)).asString().asRemote(tx()).put(value));
 });
 
 When("attribute\\({type_label}) as\\(string) put: {word}; throws exception", async (typeLabel: string, value: string) => {
-    await assertThrows(async () => await ((await tx().concepts.getAttributeType(typeLabel)) as AttributeType.String).asRemote(tx()).put(value))
+    await assertThrows(async () => await (await tx().concepts.getAttributeType(typeLabel)).asString().asRemote(tx()).put(value));
 });
 
 When("{var} = attribute\\({type_label}) as\\(datetime) put: {datetime}", async (var0: string, typeLabel: string, value: Date) => {
-    put(var0, await ((await tx().concepts.getAttributeType(typeLabel)) as AttributeType.DateTime).asRemote(tx()).put(value))
+    put(var0, await (await tx().concepts.getAttributeType(typeLabel)).asDateTime().asRemote(tx()).put(value));
 });
 
 When("attribute\\({type_label}) as\\(datetime) put: {datetime}; throws exception", async (typeLabel: string, value: Date) => {
-    await assertThrows(async () => await ((await tx().concepts.getAttributeType(typeLabel)) as AttributeType.DateTime).asRemote(tx()).put(value))
+    await assertThrows(async () => await (await tx().concepts.getAttributeType(typeLabel)).asDateTime().asRemote(tx()).put(value));
 });
 
 When("{var} = attribute\\({type_label}) as\\(boolean) get: {bool}", async (var0: string, typeLabel: string, value: boolean) => {
-    put(var0, await ((await tx().concepts.getAttributeType(typeLabel)) as AttributeType.Boolean).asRemote(tx()).get(value))
+    put(var0, await (await tx().concepts.getAttributeType(typeLabel)).asBoolean().asRemote(tx()).get(value));
 });
 
 When("{var} = attribute\\({type_label}) as\\(long) get: {int}", async (var0: string, typeLabel: string, value: number) => {
-    put(var0, await ((await tx().concepts.getAttributeType(typeLabel)) as AttributeType.Long).asRemote(tx()).get(value))
+    put(var0, await (await tx().concepts.getAttributeType(typeLabel)).asLong().asRemote(tx()).get(value));
 });
 
 When("{var} = attribute\\({type_label}) as\\(double) get: {float}", async (var0: string, typeLabel: string, value: number) => {
-    put(var0, await ((await tx().concepts.getAttributeType(typeLabel)) as AttributeType.Double).asRemote(tx()).get(value))
+    put(var0, await (await tx().concepts.getAttributeType(typeLabel)).asDouble().asRemote(tx()).get(value));
 });
 
 When("{var} = attribute\\({type_label}) as\\(string) get: {word}", async (var0: string, typeLabel: string, value: string) => {
-    put(var0, await ((await tx().concepts.getAttributeType(typeLabel)) as AttributeType.String).asRemote(tx()).get(value))
+    put(var0, await (await tx().concepts.getAttributeType(typeLabel)).asString().asRemote(tx()).get(value));
 });
 
 When("{var} = attribute\\({type_label}) as\\(datetime) get: {datetime}", async (var0: string, typeLabel: string, value: Date) => {
-    put(var0, await ((await tx().concepts.getAttributeType(typeLabel)) as AttributeType.DateTime).asRemote(tx()).get(value))
+    put(var0, await (await tx().concepts.getAttributeType(typeLabel)).asDateTime().asRemote(tx()).get(value));
 });
 
 When("attribute {var} has boolean value: {bool}", async (var0: string, value: boolean) => {
-    assert.strictEqual(value, (get(var0) as Attribute.Boolean).value)
+    assert.strictEqual(value, get(var0).asAttribute().asBoolean().value);
 });
 
 When("attribute {var} has long value: {int}", async (var0: string, value: number) => {
-    assert.strictEqual(value, (get(var0) as Attribute.Long).value)
+    assert.strictEqual(value, get(var0).asAttribute().asLong().value);
 });
 
 When("attribute {var} has double value: {float}", async (var0: string, value: number) => {
-    assert.strictEqual(value, (get(var0) as Attribute.Double).value)
+    assert.strictEqual(value, get(var0).asAttribute().asDouble().value);
 });
 
 When("attribute {var} has string value: {word}", async (var0: string, value: string) => {
-    assert.strictEqual(value, (get(var0) as Attribute.String).value)
+    assert.strictEqual(value, get(var0).asAttribute().asString().value);
 });
 
 When("attribute {var} has datetime value: {datetime}", async (var0: string, value: Date) => {
-    assert.strictEqual(value.getTime(), (get(var0) as Attribute.DateTime).value.getTime())
+    assert.strictEqual(value.getTime(), get(var0).asAttribute().asDateTime().value.getTime());
 });

--- a/test/behaviour/concept/thing/entity/EntitySteps.ts
+++ b/test/behaviour/concept/thing/entity/EntitySteps.ts
@@ -38,7 +38,7 @@ When("entity\\({type_label}) create new instance; throws exception", async (type
 
 When("{var} = entity\\({type_label}) create new instance with key\\({type_label}): {bool}",
     async (thingName: string, thingTypeLabel: string, keyTypeLabel: string, value: boolean) => {
-        const key = await ((await tx().concepts.getAttributeType(keyTypeLabel)) as AttributeType.Boolean).asRemote(tx()).put(value);
+        const key = await ((await tx().concepts.getAttributeType(keyTypeLabel)).asBoolean()).asRemote(tx()).put(value);
         const entity = await (await tx().concepts.getEntityType(thingTypeLabel)).asRemote(tx()).create();
         await entity.asRemote(tx()).setHas(key)
         put(thingName, entity);
@@ -47,7 +47,7 @@ When("{var} = entity\\({type_label}) create new instance with key\\({type_label}
 
 When("{var} = entity\\({type_label}) create new instance with key\\({type_label}): {int}",
     async (thingName: string, thingTypeLabel: string, keyTypeLabel: string, value: number) => {
-        const key = await ((await tx().concepts.getAttributeType(keyTypeLabel)) as AttributeType.Long).asRemote(tx()).put(value);
+        const key = await ((await tx().concepts.getAttributeType(keyTypeLabel)).asLong()).asRemote(tx()).put(value);
         const entity = await (await tx().concepts.getEntityType(thingTypeLabel)).asRemote(tx()).create();
         await entity.asRemote(tx()).setHas(key)
         put(thingName, entity);
@@ -56,7 +56,7 @@ When("{var} = entity\\({type_label}) create new instance with key\\({type_label}
 
 When("{var} = entity\\({type_label}) create new instance with key\\({type_label}): {word}",
     async (thingName: string, thingTypeLabel: string, keyTypeLabel: string, value: string) => {
-        const key = await ((await tx().concepts.getAttributeType(keyTypeLabel)) as AttributeType.String).asRemote(tx()).put(value);
+        const key = await ((await tx().concepts.getAttributeType(keyTypeLabel)).asString()).asRemote(tx()).put(value);
         const entity = await (await tx().concepts.getEntityType(thingTypeLabel)).asRemote(tx()).create();
         await entity.asRemote(tx()).setHas(key)
         put(thingName, entity);
@@ -65,7 +65,7 @@ When("{var} = entity\\({type_label}) create new instance with key\\({type_label}
 
 When("{var} = entity\\({type_label}) create new instance with key\\({type_label}): {datetime}",
     async (thingName: string, thingTypeLabel: string, keyTypeLabel: string, value: Date) => {
-        const key = await ((await tx().concepts.getAttributeType(keyTypeLabel)) as AttributeType.DateTime).asRemote(tx()).put(value);
+        const key = await ((await tx().concepts.getAttributeType(keyTypeLabel)).asDateTime()).asRemote(tx()).put(value);
         const entity = await (await tx().concepts.getEntityType(thingTypeLabel)).asRemote(tx()).create();
         await entity.asRemote(tx()).setHas(key)
         put(thingName, entity);
@@ -74,7 +74,7 @@ When("{var} = entity\\({type_label}) create new instance with key\\({type_label}
 
 When("{var} = entity\\({type_label}) get instance with key\\({type_label}): {bool}",
     async (thingName: string, thingTypeLabel: string, keyTypeLabel: string, value: boolean) => {
-        const key = await ((await tx().concepts.getAttributeType(keyTypeLabel)) as AttributeType.Boolean).asRemote(tx()).get(value);
+        const key = await ((await tx().concepts.getAttributeType(keyTypeLabel)).asBoolean()).asRemote(tx()).get(value);
         for await (const owner of key.asRemote(tx()).getOwners()) {
             if (owner.type.label.scopedName === thingTypeLabel) {
                 put(thingName, owner);
@@ -87,7 +87,7 @@ When("{var} = entity\\({type_label}) get instance with key\\({type_label}): {boo
 
 When("{var} = entity\\({type_label}) get instance with key\\({type_label}): {int}",
     async (thingName: string, thingTypeLabel: string, keyTypeLabel: string, value: number) => {
-        const key = await ((await tx().concepts.getAttributeType(keyTypeLabel)) as AttributeType.Long).asRemote(tx()).get(value);
+        const key = await ((await tx().concepts.getAttributeType(keyTypeLabel)).asLong()).asRemote(tx()).get(value);
         for await (const owner of key.asRemote(tx()).getOwners()) {
             if (owner.type.label.scopedName === thingTypeLabel) {
                 put(thingName, owner);
@@ -100,7 +100,7 @@ When("{var} = entity\\({type_label}) get instance with key\\({type_label}): {int
 
 When("{var} = entity\\({type_label}) get instance with key\\({type_label}): {word}",
     async (thingName: string, thingTypeLabel: string, keyTypeLabel: string, value: string) => {
-        const key = await ((await tx().concepts.getAttributeType(keyTypeLabel)) as AttributeType.String).asRemote(tx()).get(value);
+        const key = await ((await tx().concepts.getAttributeType(keyTypeLabel)).asString()).asRemote(tx()).get(value);
         for await (const owner of key.asRemote(tx()).getOwners()) {
             if (owner.type.label.scopedName === thingTypeLabel) {
                 put(thingName, owner);
@@ -113,7 +113,7 @@ When("{var} = entity\\({type_label}) get instance with key\\({type_label}): {wor
 
 When("{var} = entity\\({type_label}) get instance with key\\({type_label}): {datetime}",
     async (thingName: string, thingTypeLabel: string, keyTypeLabel: string, value: Date) => {
-        const key = await ((await tx().concepts.getAttributeType(keyTypeLabel)) as AttributeType.DateTime).asRemote(tx()).get(value);
+        const key = await ((await tx().concepts.getAttributeType(keyTypeLabel)).asDateTime()).asRemote(tx()).get(value);
         for await (const owner of key.asRemote(tx()).getOwners()) {
             if ((await owner.asRemote(tx()).type).equals(await tx().concepts.getEntityType(thingTypeLabel))) {
                 put(thingName, owner);

--- a/test/behaviour/concept/thing/relation/RelationSteps.ts
+++ b/test/behaviour/concept/thing/relation/RelationSteps.ts
@@ -38,7 +38,7 @@ When("relation\\({type_label}) create new instance; throws exception", async (ty
 
 When("{var} = relation\\({type_label}) create new instance with key\\({type_label}): {bool}",
     async (thingName: string, thingTypeLabel: string, keyTypeLabel: string, value: boolean) => {
-        const key = await ((await tx().concepts.getAttributeType(keyTypeLabel)) as AttributeType.Boolean).asRemote(tx()).put(value);
+        const key = await ((await tx().concepts.getAttributeType(keyTypeLabel)).asBoolean()).asRemote(tx()).put(value);
         const relation = await (await tx().concepts.getRelationType(thingTypeLabel)).asRemote(tx()).create();
         await relation.asRemote(tx()).setHas(key)
         put(thingName, relation);
@@ -47,7 +47,7 @@ When("{var} = relation\\({type_label}) create new instance with key\\({type_labe
 
 When("{var} = relation\\({type_label}) create new instance with key\\({type_label}): {int}",
     async (thingName: string, thingTypeLabel: string, keyTypeLabel: string, value: number) => {
-        const key = await ((await tx().concepts.getAttributeType(keyTypeLabel)) as AttributeType.Long).asRemote(tx()).put(value);
+        const key = await ((await tx().concepts.getAttributeType(keyTypeLabel)).asLong()).asRemote(tx()).put(value);
         const relation = await (await tx().concepts.getRelationType(thingTypeLabel)).asRemote(tx()).create();
         await relation.asRemote(tx()).setHas(key)
         put(thingName, relation);
@@ -56,7 +56,7 @@ When("{var} = relation\\({type_label}) create new instance with key\\({type_labe
 
 When("{var} = relation\\({type_label}) create new instance with key\\({type_label}): {word}",
     async (thingName: string, thingTypeLabel: string, keyTypeLabel: string, value: string) => {
-        const key = await ((await tx().concepts.getAttributeType(keyTypeLabel)) as AttributeType.String).asRemote(tx()).put(value);
+        const key = await ((await tx().concepts.getAttributeType(keyTypeLabel)).asString()).asRemote(tx()).put(value);
         const relation = await (await tx().concepts.getRelationType(thingTypeLabel)).asRemote(tx()).create();
         await relation.asRemote(tx()).setHas(key)
         put(thingName, relation);
@@ -65,7 +65,7 @@ When("{var} = relation\\({type_label}) create new instance with key\\({type_labe
 
 When("{var} = relation\\({type_label}) create new instance with key\\({type_label}): {datetime}",
     async (thingName: string, thingTypeLabel: string, keyTypeLabel: string, value: Date) => {
-        const key = await ((await tx().concepts.getAttributeType(keyTypeLabel)) as AttributeType.DateTime).asRemote(tx()).put(value);
+        const key = await ((await tx().concepts.getAttributeType(keyTypeLabel)).asDateTime()).asRemote(tx()).put(value);
         const relation = await (await tx().concepts.getRelationType(thingTypeLabel)).asRemote(tx()).create();
         await relation.asRemote(tx()).setHas(key)
         put(thingName, relation);
@@ -74,7 +74,7 @@ When("{var} = relation\\({type_label}) create new instance with key\\({type_labe
 
 When("{var} = relation\\({type_label}) get instance with key\\({type_label}): {bool}",
     async (thingName: string, thingTypeLabel: string, keyTypeLabel: string, value: boolean) => {
-        const key = await ((await tx().concepts.getAttributeType(keyTypeLabel)) as AttributeType.Boolean).asRemote(tx()).get(value);
+        const key = await ((await tx().concepts.getAttributeType(keyTypeLabel)).asBoolean()).asRemote(tx()).get(value);
         for await (const owner of key.asRemote(tx()).getOwners()) {
             if (owner.type.label.scopedName === thingTypeLabel) {
                 put(thingName, owner);
@@ -87,7 +87,7 @@ When("{var} = relation\\({type_label}) get instance with key\\({type_label}): {b
 
 When("{var} = relation\\({type_label}) get instance with key\\({type_label}): {int}",
     async (thingName: string, thingTypeLabel: string, keyTypeLabel: string, value: number) => {
-        const key = await ((await tx().concepts.getAttributeType(keyTypeLabel)) as AttributeType.Long).asRemote(tx()).get(value);
+        const key = await ((await tx().concepts.getAttributeType(keyTypeLabel)).asLong()).asRemote(tx()).get(value);
         for await (const owner of key.asRemote(tx()).getOwners()) {
             if (owner.type.label.scopedName === thingTypeLabel) {
                 put(thingName, owner);
@@ -100,7 +100,7 @@ When("{var} = relation\\({type_label}) get instance with key\\({type_label}): {i
 
 When("{var} = relation\\({type_label}) get instance with key\\({type_label}): {word}",
     async (thingName: string, thingTypeLabel: string, keyTypeLabel: string, value: string) => {
-        const key = await ((await tx().concepts.getAttributeType(keyTypeLabel)) as AttributeType.String).asRemote(tx()).get(value);
+        const key = await ((await tx().concepts.getAttributeType(keyTypeLabel)).asString()).asRemote(tx()).get(value);
         for await (const owner of key.asRemote(tx()).getOwners()) {
             if (owner.type.label.scopedName === thingTypeLabel) {
                 put(thingName, owner);
@@ -113,7 +113,7 @@ When("{var} = relation\\({type_label}) get instance with key\\({type_label}): {w
 
 When("{var} = relation\\({type_label}) get instance with key\\({type_label}): {datetime}",
     async (thingName: string, thingTypeLabel: string, keyTypeLabel: string, value: Date) => {
-        const key = await ((await tx().concepts.getAttributeType(keyTypeLabel)) as AttributeType.DateTime).asRemote(tx()).get(value);
+        const key = await ((await tx().concepts.getAttributeType(keyTypeLabel)).asDateTime()).asRemote(tx()).get(value);
         for await (const owner of key.asRemote(tx()).getOwners()) {
             if ((await owner.asRemote(tx()).type).equals(await tx().concepts.getRelationType(thingTypeLabel))) {
                 put(thingName, owner);
@@ -142,7 +142,7 @@ When("relation\\({type_label}) get instances is empty", async (typeLabel: string
 });
 
 When("relation {var} add player for role\\({type_label}): {var}", async (relationName: string, typeLabel: string, playerName: string) => {
-    const relation = get(relationName) as Relation;
+    const relation = get(relationName).asRelation();
     const roleType = await relation.type.asRemote(tx()).getRelates(typeLabel);
     const player = get(playerName);
     await relation.asRemote(tx()).addPlayer(roleType, player);
@@ -150,7 +150,7 @@ When("relation {var} add player for role\\({type_label}): {var}", async (relatio
 
 When("relation {var} add player for role\\({type_label}): {var}; throws exception", async (relationName: string, typeLabel: string, playerName: string) => {
     await assertThrows(async () => {
-        const relation = get(relationName) as Relation;
+        const relation = get(relationName).asRelation();
         const roleType = await relation.type.asRemote(tx()).getRelates(typeLabel);
         const player = get(playerName);
         await relation.asRemote(tx()).addPlayer(roleType, player);
@@ -158,14 +158,14 @@ When("relation {var} add player for role\\({type_label}): {var}; throws exceptio
 });
 
 When("relation {var} remove player for role\\({type_label}): {var}", async (relationName: string, typeLabel: string, playerName: string) => {
-    const relation = get(relationName) as Relation;
+    const relation = get(relationName).asRelation();
     const roleType = await relation.type.asRemote(tx()).getRelates(typeLabel);
     const player = get(playerName);
     await relation.asRemote(tx()).removePlayer(roleType, player);
 });
 
 When("relation {var} get players contain:", async (var1: string, players: DataTable) => {
-    const relation = get(var1) as Relation;
+    const relation = get(var1).asRelation();
     const playersByRoleType = await relation.asRemote(tx()).getPlayersByRoleType();
     for (const [roleLabel, var2Raw] of players.raw()) {
         const var2 = parseVar(var2Raw);
@@ -176,7 +176,7 @@ When("relation {var} get players contain:", async (var1: string, players: DataTa
 });
 
 When("relation {var} get players do not contain:", async (var1: string, players: DataTable) => {
-    const relation = get(var1) as Relation;
+    const relation = get(var1).asRelation();
     const playersByRoleType = await relation.asRemote(tx()).getPlayersByRoleType();
     for (const [roleLabel, var2Raw] of players.raw()) {
         const var2 = parseVar(var2Raw);
@@ -186,19 +186,19 @@ When("relation {var} get players do not contain:", async (var1: string, players:
 });
 
 When("relation {var} get players contain: {var}", async (var1: string, var2: string) => {
-    assert(await (get(var1) as Relation).asRemote(tx()).getPlayers().some(x => x.equals(get(var2))));
+    assert(await get(var1).asRelation().asRemote(tx()).getPlayers().some(x => x.equals(get(var2))));
 });
 
 When("relation {var} get players do not contain: {var}", async (var1: string, var2: string) => {
-    assert(!(await (get(var1) as Relation).asRemote(tx()).getPlayers().some(x => x.equals(get(var2)))));
+    assert(!(await get(var1).asRelation().asRemote(tx()).getPlayers().some(x => x.equals(get(var2)))));
 });
 
 When("relation {var} get players for role\\({type_label}) contain: {var}", async (var1: string, roleLabel: string, var2: string) => {
-    const roleType = await (get(var1) as Relation).type.asRemote(tx()).getRelates(roleLabel);
-    assert(await (get(var1) as Relation).asRemote(tx()).getPlayers([roleType]).some(x => x.equals(get(var2))));
+    const roleType = await get(var1).asRelation().type.asRemote(tx()).getRelates(roleLabel);
+    assert(await get(var1).asRelation().asRemote(tx()).getPlayers([roleType]).some(x => x.equals(get(var2))));
 });
 
 When("relation {var} get players for role\\({type_label}) do not contain: {var}", async (var1: string, roleLabel: string, var2: string) => {
-    const roleType = await (get(var1) as Relation).type.asRemote(tx()).getRelates(roleLabel);
-    assert(!(await (get(var1) as Relation).asRemote(tx()).getPlayers([roleType]).some(x => x.equals(get(var2)))));
+    const roleType = await get(var1).asRelation().type.asRemote(tx()).getRelates(roleLabel);
+    assert(!(await get(var1).asRelation().asRemote(tx()).getPlayers([roleType]).some(x => x.equals(get(var2)))));
 });

--- a/test/behaviour/concept/type/attributetype/AttributeTypeSteps.ts
+++ b/test/behaviour/concept/type/attributetype/AttributeTypeSteps.ts
@@ -37,7 +37,7 @@ Then("attribute\\({type_label}) get value type: {value_type}", async (typeLabel:
 
 Then("attribute\\({type_label}) get supertype value type: {value_type}", async (typeLabel: string, valueType: ValueType) => {
     const supertype = await (await tx().concepts.getAttributeType(typeLabel)).asRemote(tx()).getSupertype();
-    assert.strictEqual((supertype as AttributeType).valueType, valueType);
+    assert.strictEqual(supertype.asAttributeType().valueType, valueType);
 });
 
 async function attributeTypeAsValueType(typeLabel: string, valueType: ValueType) {

--- a/test/behaviour/typeql/TypeQLSteps.ts
+++ b/test/behaviour/typeql/TypeQLSteps.ts
@@ -176,8 +176,7 @@ class TypeLabelMatcher implements ConceptMatcher {
     }
 
     async matches(concept: Concept): Promise<boolean> {
-        if (concept.isRoleType()) return this.label == (concept as RoleType).label.scopedName;
-        else if (concept.isType()) return this.label == (concept as Type).label.scopedName;
+        if (concept.isType()) return this.label == concept.asType().label.scopedName;
         else throw new TypeError("A Concept was matched by label, but it is not a Type.");
     }
 }
@@ -217,7 +216,7 @@ class AttributeValueMatcher extends AttributeMatcher {
     async matches(concept: Concept): Promise<boolean> {
         if (!concept.isAttribute()) return false;
 
-        const attribute = concept as Attribute;
+        const attribute = concept.asAttribute();
 
         if (this.typeLabel !== attribute.type.label.scopedName) return false;
 
@@ -230,7 +229,7 @@ class ThingKeyMatcher extends AttributeMatcher {
     async matches(concept: Concept): Promise<boolean> {
         if (!concept.isThing()) return false;
 
-        const keys = await (concept as Thing).asRemote(tx()).getHas(true).collect();
+        const keys = await concept.asThing().asRemote(tx()).getHas(true).collect();
 
         for (const key of keys) {
             if (key.type.label.scopedName === this.typeLabel) {
@@ -425,7 +424,7 @@ function applyQueryTemplate(template: string, answer: ConceptMap): string {
         if (answer.map.has(requiredVariable)) {
             const concept = answer.get(requiredVariable);
             if (!concept.isThing()) throw new TypeError("Cannot apply IID templating to Types");
-            query += (concept as Thing).iid;
+            query += concept.asThing().iid;
         } else {
             throw new Error(`No IID available for template placeholder: [${match[0]}]`);
         }

--- a/test/deployment/application.test.js
+++ b/test/deployment/application.test.js
@@ -48,7 +48,7 @@ describe("Basic TypeDBClient Tests", () => {
     test("define by running query", async () => {
         let session = await client.session("typedb", SessionType.SCHEMA);
         let tx = await session.transaction(TransactionType.WRITE);
-        await tx.query.match("define person sub entity, owns name; name sub attribute, value string;");
+        await tx.query.define("define person sub entity, owns name; name sub attribute, value string;");
         await tx.commit();
         return await session.close();
     });


### PR DESCRIPTION
## What is the goal of this PR?

Our internal code now makes use of the "asX" methods in the Concept package, instead of type casting.

## What are the changes implemented in this PR?

Use "asX" methods instead of type casts