### PR TITLE
Improve UX of TypeDBClientError

### DIFF
--- a/common/errors/TypeDBClientError.ts
+++ b/common/errors/TypeDBClientError.ts
@@ -29,6 +29,10 @@ function isReplicaNotPrimaryError(e: ServiceError): boolean {
     return e.message.includes("[RPL01]");
 }
 
+function isServiceError(e: Error | ServiceError): e is ServiceError {
+    return "code" in e;
+}
+
 export class TypeDBClientError extends Error {
     private readonly _messageTemplate: ErrorMessage;
 
@@ -39,7 +43,7 @@ export class TypeDBClientError extends Error {
             this._messageTemplate = error;
         }
         // TODO: clean this up once we have our own error protocol
-        else if ("code" in error) { // check for gRPC ServiceError
+        else if (isServiceError(error)) {
             if ([Status.UNAVAILABLE, Status.UNKNOWN, Status.CANCELLED].includes(error.code) || error.message.includes("Received RST_STREAM")) {
                 super(UNABLE_TO_CONNECT.message());
                 this._messageTemplate = UNABLE_TO_CONNECT;

--- a/common/errors/TypeDBClientError.ts
+++ b/common/errors/TypeDBClientError.ts
@@ -40,14 +40,14 @@ export class TypeDBClientError extends Error {
         }
         // TODO: clean this up once we have our own error protocol
         else if ("code" in error) {
-            if (error.code === Status.INTERNAL) super(error.details);
-            else if ([Status.UNAVAILABLE, Status.UNKNOWN, Status.CANCELLED].includes(error.code) || error.message.includes("Received RST_STREAM")) {
+            if ([Status.UNAVAILABLE, Status.UNKNOWN, Status.CANCELLED].includes(error.code) || error.message.includes("Received RST_STREAM")) {
                 super(UNABLE_TO_CONNECT.message());
                 this._messageTemplate = UNABLE_TO_CONNECT;
             } else if (isReplicaNotPrimaryError(error)) {
                 super(CLUSTER_REPLICA_NOT_PRIMARY.message());
                 this._messageTemplate = CLUSTER_REPLICA_NOT_PRIMARY;
-            } else super(error.toString());
+            } else if (error.code === Status.INTERNAL) super(error.details)
+            else super(error.toString());
         }
         else super(error.toString());
 

--- a/common/errors/TypeDBClientError.ts
+++ b/common/errors/TypeDBClientError.ts
@@ -39,7 +39,7 @@ export class TypeDBClientError extends Error {
             this._messageTemplate = error;
         }
         // TODO: clean this up once we have our own error protocol
-        else if ("code" in error) {
+        else if ("code" in error) { // check for gRPC ServiceError
             if ([Status.UNAVAILABLE, Status.UNKNOWN, Status.CANCELLED].includes(error.code) || error.message.includes("Received RST_STREAM")) {
                 super(UNABLE_TO_CONNECT.message());
                 this._messageTemplate = UNABLE_TO_CONNECT;

--- a/connection/cluster/ClusterDatabaseManager.ts
+++ b/connection/cluster/ClusterDatabaseManager.ts
@@ -91,7 +91,7 @@ export class ClusterDatabaseManager implements DatabaseManager.Cluster {
         try {
             return await failsafeTask.runAnyReplica();
         } catch (e) {
-            if (e instanceof TypeDBClientError && CLUSTER_REPLICA_NOT_PRIMARY === e.errorMessage) {
+            if (e instanceof TypeDBClientError && CLUSTER_REPLICA_NOT_PRIMARY === e.messageTemplate) {
                 return await failsafeTask.runPrimaryReplica();
             } else throw e;
         }

--- a/connection/cluster/FailsafeTask.ts
+++ b/connection/cluster/FailsafeTask.ts
@@ -67,7 +67,7 @@ export abstract class FailsafeTask<TResult> {
             try {
                 return retries == 0 ? await this.run(replica) : await this.rerun(replica);
             } catch (e) {
-                if (e instanceof TypeDBClientError && [CLUSTER_REPLICA_NOT_PRIMARY, UNABLE_TO_CONNECT].includes(e.errorMessage)) {
+                if (e instanceof TypeDBClientError && [CLUSTER_REPLICA_NOT_PRIMARY, UNABLE_TO_CONNECT].includes(e.messageTemplate)) {
                     console.info("Unable to open a session or transaction, retrying in 2s...", e);
                     await this.waitForPrimaryReplicaSelection();
                     replica = await this.seekPrimaryReplica();
@@ -90,7 +90,7 @@ export abstract class FailsafeTask<TResult> {
             try {
                 return retries == 0 ? await this.run(replica) : await this.rerun(replica);
             } catch (e) {
-                if (e instanceof TypeDBClientError && UNABLE_TO_CONNECT === e.errorMessage) {
+                if (e instanceof TypeDBClientError && UNABLE_TO_CONNECT === e.messageTemplate) {
                     console.info("Unable to open a session or transaction to " + replica + ". Attempting next replica.", e);
                 } else throw e;
             }


### PR DESCRIPTION
## What is the goal of this PR?

Previously, the `TypeDBClientError` constructor was a bit of a mess, meaning that under certain scenarios, the user was interested in `error.message`; in other scenarios, `error.errorMessage`, and this was pretty ridiculous because the two names are basically synonymous.

So we renamed `errorMessage` to `messageTemplate`, and ensured that the content of `error.message` is always a human-readable string.

## What are the changes implemented in this PR?

- Rename `TypeDBClientError.errorMessage` to `messageTemplate` to reduce likelihood of confusing it with `message`
- Ensure content of `error.message` is always a human-readable string