### PR TITLE
Store error on transaction stream and clean up completed query state

### DIFF
--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -77,13 +77,13 @@ build:
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
         .grabl/test-core.sh //test/behaviour/connection/... --test_output=errors --jobs=1
-#    test-behaviour-connection-cluster:
-#      image: vaticle-ubuntu-21.04
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        .grabl/test-cluster.sh //test/behaviour/connection/... --test_output=errors --jobs=1
+    test-behaviour-connection-cluster:
+      image: vaticle-ubuntu-21.04
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        .grabl/test-cluster.sh //test/behaviour/connection/... --test_output=errors --jobs=1
     test-behaviour-concept-core:
       image: vaticle-ubuntu-21.04
       command: |
@@ -107,14 +107,14 @@ build:
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
         .grabl/test-core.sh //test/behaviour/typeql/language/match/... --test_output=errors --jobs=1
         .grabl/test-core.sh //test/behaviour/typeql/language/get/... --test_output=errors --jobs=1
-#    test-behaviour-match-cluster:
-#      image: vaticle-ubuntu-21.04
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        .grabl/test-cluster.sh //test/behaviour/typeql/language/match/... --test_output=errors --jobs=1
-#        .grabl/test-cluster.sh //test/behaviour/typeql/language/get/... --test_output=errors --jobs=1
+    test-behaviour-match-cluster:
+      image: vaticle-ubuntu-21.04
+      command: |
+        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        .grabl/test-cluster.sh //test/behaviour/typeql/language/match/... --test_output=errors --jobs=1
+        .grabl/test-cluster.sh //test/behaviour/typeql/language/get/... --test_output=errors --jobs=1
     test-behaviour-writable-core:
       image: vaticle-ubuntu-21.04
       command: |
@@ -156,9 +156,9 @@ build:
       image: vaticle-ubuntu-21.04
       dependencies: [
         build, test-integration,
-        test-behaviour-connection-core, #test-behaviour-connection-cluster,
+        test-behaviour-connection-core, test-behaviour-connection-cluster,
         test-behaviour-concept-core, test-behaviour-concept-cluster,
-        test-behaviour-match-core, #test-behaviour-match-cluster,
+        test-behaviour-match-core, test-behaviour-match-cluster,
         test-behaviour-writable-core, test-behaviour-writable-cluster,
         test-behaviour-definable-core, test-behaviour-definable-cluster
       ]

--- a/connection/TypeDBTransactionImpl.ts
+++ b/connection/TypeDBTransactionImpl.ts
@@ -34,7 +34,6 @@ import {LogicManagerImpl} from "../logic/LogicManagerImpl";
 import {QueryManagerImpl} from "../query/QueryManagerImpl";
 import {BidirectionalStream} from "../stream/BidirectionalStream";
 import {TypeDBSessionImpl} from "./TypeDBSessionImpl";
-import assert = require("assert");
 import TRANSACTION_CLOSED = ErrorMessage.Client.TRANSACTION_CLOSED;
 import TRANSACTION_CLOSED_WITH_ERRORS = ErrorMessage.Client.TRANSACTION_CLOSED_WITH_ERRORS;
 import ILLEGAL_STATE = ErrorMessage.Internal.ILLEGAL_STATE;
@@ -120,8 +119,8 @@ export class TypeDBTransactionImpl implements TypeDBTransaction.Extended {
 
     private throwTransactionClosed(): void {
         if (this.isOpen()) throw new TypeDBClientError(ILLEGAL_STATE);
-        const errors = this._bidirectionalStream.getErrors();
-        if (errors.length == 0) throw new TypeDBClientError(TRANSACTION_CLOSED);
-        else throw new TypeDBClientError(TRANSACTION_CLOSED_WITH_ERRORS.message(errors));
+        const error = this._bidirectionalStream.getError();
+        if (!error) throw new TypeDBClientError(TRANSACTION_CLOSED);
+        else throw new TypeDBClientError(TRANSACTION_CLOSED_WITH_ERRORS.message(error));
     }
 }

--- a/query/QueryManagerImpl.ts
+++ b/query/QueryManagerImpl.ts
@@ -19,23 +19,23 @@
  * under the License.
  */
 
-import { QueryManager as QueryProto } from "typedb-protocol/common/query_pb";
-import { Transaction as TransactionProto } from "typedb-protocol/common/transaction_pb";
-import { ConceptMap } from "../api/answer/ConceptMap";
-import { ConceptMapGroup } from "../api/answer/ConceptMapGroup";
-import { Numeric } from "../api/answer/Numeric";
-import { NumericGroup } from "../api/answer/NumericGroup";
-import { TypeDBOptions } from "../api/connection/TypeDBOptions";
-import { TypeDBTransaction } from "../api/connection/TypeDBTransaction";
-import { Explanation } from "../api/logic/Explanation";
-import { QueryManager } from "../api/query/QueryManager";
-import { RequestBuilder } from "../common/rpc/RequestBuilder";
-import { Stream } from "../common/util/Stream";
-import { ConceptMapGroupImpl } from "../concept/answer/ConceptMapGroupImpl";
-import { ConceptMapImpl } from "../concept/answer/ConceptMapImpl";
-import { NumericGroupImpl } from "../concept/answer/NumericGroupImpl";
-import { NumericImpl } from "../concept/answer/NumericImpl";
-import { ExplanationImpl } from "../logic/ExplanationImpl";
+import {QueryManager as QueryProto} from "typedb-protocol/common/query_pb";
+import {Transaction as TransactionProto} from "typedb-protocol/common/transaction_pb";
+import {ConceptMap} from "../api/answer/ConceptMap";
+import {ConceptMapGroup} from "../api/answer/ConceptMapGroup";
+import {Numeric} from "../api/answer/Numeric";
+import {NumericGroup} from "../api/answer/NumericGroup";
+import {TypeDBOptions} from "../api/connection/TypeDBOptions";
+import {TypeDBTransaction} from "../api/connection/TypeDBTransaction";
+import {Explanation} from "../api/logic/Explanation";
+import {QueryManager} from "../api/query/QueryManager";
+import {RequestBuilder} from "../common/rpc/RequestBuilder";
+import {Stream} from "../common/util/Stream";
+import {ConceptMapGroupImpl} from "../concept/answer/ConceptMapGroupImpl";
+import {ConceptMapImpl} from "../concept/answer/ConceptMapImpl";
+import {NumericGroupImpl} from "../concept/answer/NumericGroupImpl";
+import {NumericImpl} from "../concept/answer/NumericImpl";
+import {ExplanationImpl} from "../logic/ExplanationImpl";
 
 
 export class QueryManagerImpl implements QueryManager {

--- a/stream/BidirectionalStream.ts
+++ b/stream/BidirectionalStream.ts
@@ -63,9 +63,11 @@ export class BidirectionalStream {
         const responseQueue = this._responseCollector.queue(requestId);
         if (batch) this._dispatcher.dispatch(request);
         else this._dispatcher.dispatchNow(request);
-        const value = await responseQueue.take() as Transaction.Res;
-        this._responseCollector.remove(requestId);
-        return value;
+        try {
+            return await responseQueue.take() as Transaction.Res;
+        } finally {    
+            this._responseCollector.remove(requestId);
+        }
     }
 
     stream(request: Transaction.Req): Stream<Transaction.ResPart> {

--- a/stream/ResponseCollector.ts
+++ b/stream/ResponseCollector.ts
@@ -41,6 +41,10 @@ export class ResponseCollector<T> {
         return this._response_queues[uuid];
     }
 
+    remove(requestId: string) {
+        delete this._response_queues[requestId];
+    }
+
     close(error?: Error | string) {
         Object.values(this._response_queues).forEach(collector => collector.close(error));
     }
@@ -50,7 +54,7 @@ export class ResponseCollector<T> {
         for (const requestId in this._response_queues) {
             const error = this._response_queues[requestId].getError();
             if (error) errors.push(error);
-            delete this._response_queues[requestId];
+            this.remove(requestId);
         }
         return errors;
     }

--- a/stream/ResponseCollector.ts
+++ b/stream/ResponseCollector.ts
@@ -48,16 +48,6 @@ export class ResponseCollector<T> {
     close(error?: Error | string) {
         Object.values(this._response_queues).forEach(collector => collector.close(error));
     }
-
-    getErrors(): (Error | string)[] {
-        const errors: (Error | string)[] = [];
-        for (const requestId in this._response_queues) {
-            const error = this._response_queues[requestId].getError();
-            if (error) errors.push(error);
-            this.remove(requestId);
-        }
-        return errors;
-    }
 }
 
 export namespace ResponseCollector {
@@ -89,10 +79,6 @@ export namespace ResponseCollector {
         close(error?: Error | string): void {
             this._error = error;
             this._queue.add(new Done());
-        }
-
-        getError(): string | Error {
-            return this._error;
         }
     }
 

--- a/stream/ResponsePartIterator.ts
+++ b/stream/ResponsePartIterator.ts
@@ -52,6 +52,7 @@ export class ResponsePartIterator implements AsyncIterable<Transaction.ResPart> 
     }
 
     async next(): Promise<Transaction.ResPart> {
+        if (this._stream.getError()) throw this._stream.getError();
         const res = await this._responseCollector.take();
         switch (res.getResCase()) {
             case ResCase.RES_NOT_SET:

--- a/stream/ResponsePartIterator.ts
+++ b/stream/ResponsePartIterator.ts
@@ -28,18 +28,19 @@ import { ResponseCollector } from "./ResponseCollector";
 import MISSING_RESPONSE = ErrorMessage.Client.MISSING_RESPONSE;
 import UNKNOWN_STREAM_STATE = ErrorMessage.Client.UNKNOWN_STREAM_STATE;
 import ResCase = Transaction.ResPart.ResCase;
+import {BidirectionalStream} from "./BidirectionalStream";
 
 export class ResponsePartIterator implements AsyncIterable<Transaction.ResPart> {
 
     private readonly _requestId: string;
-    private readonly _dispatcher: BatchDispatcher;
     private readonly _responseCollector: ResponseCollector.ResponseQueue<Transaction.ResPart>;
+    private readonly _stream: BidirectionalStream;
 
     constructor(requestId: string, responseCollector: ResponseCollector.ResponseQueue<Transaction.ResPart>,
-                dispatcher: BatchDispatcher) {
+                stream: BidirectionalStream) {
         this._requestId = requestId;
-        this._dispatcher = dispatcher;
         this._responseCollector = responseCollector;
+        this._stream = stream;
     }
 
     async* [Symbol.asyncIterator](): AsyncIterator<Transaction.ResPart, any, undefined> {
@@ -58,9 +59,10 @@ export class ResponsePartIterator implements AsyncIterable<Transaction.ResPart> 
             case ResCase.STREAM_RES_PART :
                 switch (res.getStreamResPart().getState()) {
                     case Transaction.Stream.State.DONE:
+                        this._stream.iteratorDone(this._requestId);
                         return null;
                     case Transaction.Stream.State.CONTINUE:
-                        this._dispatcher.dispatch(RequestBuilder.Transaction.streamReq(this._requestId))
+                        this._stream.dispatcher().dispatch(RequestBuilder.Transaction.streamReq(this._requestId))
                         return this.next();
                     default:
                         throw new TypeDBClientError(UNKNOWN_STREAM_STATE.message(res.getStreamResPart()));


### PR DESCRIPTION
## What is the goal of this PR?

Multiplexed query streams over the transaction stream are cleaned up when complete. We also store any exceptions received against the transaction stream (as well as query streams) in order to propagate the error to any future transaction operations, not just open query streams.

## What are the changes implemented in this PR?

* Remove single and iterator response queues when they are finished
* store errors against query streams and transaction streams, so we can error on transaction operations against a closed transaction