### PR TITLE
Query iterator only throws exeption once 

### DIFF
--- a/stream/BidirectionalStream.ts
+++ b/stream/BidirectionalStream.ts
@@ -70,7 +70,7 @@ export class BidirectionalStream {
         const requestId = uuid.v4();
         request.setReqId(uuid.parse(requestId) as Uint8Array);
         const responseQueue = this._responsePartCollector.queue(requestId) as ResponseQueue<Transaction.ResPart>;
-        const responseIterator = new ResponsePartIterator(requestId, responseQueue, this);
+        const responseIterator = new ResponsePartIterator(requestId, responseQueue, this._dispatcher);
         this._dispatcher.dispatch(request);
         return Stream.iterable(responseIterator);
     }

--- a/stream/RequestTransmitter.ts
+++ b/stream/RequestTransmitter.ts
@@ -19,9 +19,9 @@
  * under the License.
  */
 
-import { ClientDuplexStream } from "@grpc/grpc-js";
-import { Transaction as TransactionProto } from "typedb-protocol/common/transaction_pb";
-import { RequestBuilder } from "../common/rpc/RequestBuilder";
+import {ClientDuplexStream} from "@grpc/grpc-js";
+import {Transaction as TransactionProto} from "typedb-protocol/common/transaction_pb";
+import {RequestBuilder} from "../common/rpc/RequestBuilder";
 
 export class BatchDispatcher {
 

--- a/stream/ResponseCollector.ts
+++ b/stream/ResponseCollector.ts
@@ -54,11 +54,9 @@ export namespace ResponseCollector {
 
     import TRANSACTION_CLOSED = ErrorMessage.Client.TRANSACTION_CLOSED;
     import ILLEGAL_STATE = ErrorMessage.Internal.ILLEGAL_STATE;
-    import TRANSACTION_CLOSED_WITH_ERRORS = ErrorMessage.Client.TRANSACTION_CLOSED_WITH_ERRORS;
 
     export class ResponseQueue<T> {
         private readonly _queue: BlockingQueue<QueueElement>;
-        private _error: string | Error = null;
 
         constructor() {
             this._queue = new BlockingQueue<QueueElement>()
@@ -67,9 +65,13 @@ export namespace ResponseCollector {
         async take(): Promise<T> {
             const element = await this._queue.take();
             if (element.isValue()) return (element as Value<T>).value;
-            else if (element.isDone() && !this._error) throw new TypeDBClientError(TRANSACTION_CLOSED);
-            else if (element.isDone() && this._error) throw new TypeDBClientError(TRANSACTION_CLOSED_WITH_ERRORS.message(this._error));
-            else throw new TypeDBClientError(ILLEGAL_STATE);
+            else if (element.isDone()) {
+                if ((element as Done).hasError()) {
+                    throw new TypeDBClientError((element as Done).error);
+                } else {
+                    throw new TypeDBClientError(TRANSACTION_CLOSED);
+                }
+            } else throw new TypeDBClientError(ILLEGAL_STATE);
         }
 
         put(element: T): void {
@@ -77,8 +79,7 @@ export namespace ResponseCollector {
         }
 
         close(error?: Error | string): void {
-            this._error = error;
-            this._queue.add(new Done());
+            this._queue.add(new Done(error));
         }
     }
 
@@ -113,14 +114,23 @@ export namespace ResponseCollector {
     }
 
     class Done extends QueueElement {
+        private readonly _error?: Error | string;
 
-        constructor() {
+        constructor(error?: Error | string) {
             super();
+            this._error = error;
+        }
+
+        hasError(): boolean {
+            return this._error != null;
+        }
+
+        get error(): Error | string {
+            return this._error;
         }
 
         isDone(): boolean {
             return true;
         }
     }
-
 }

--- a/stream/ResponsePartIterator.ts
+++ b/stream/ResponsePartIterator.ts
@@ -19,16 +19,15 @@
  * under the License.
  */
 
-import { Transaction } from "typedb-protocol/common/transaction_pb";
-import { ErrorMessage } from "../common/errors/ErrorMessage";
-import { TypeDBClientError } from "../common/errors/TypeDBClientError";
-import { RequestBuilder } from "../common/rpc/RequestBuilder";
-import { BatchDispatcher } from "./RequestTransmitter";
-import { ResponseCollector } from "./ResponseCollector";
+import {Transaction} from "typedb-protocol/common/transaction_pb";
+import {ErrorMessage} from "../common/errors/ErrorMessage";
+import {TypeDBClientError} from "../common/errors/TypeDBClientError";
+import {RequestBuilder} from "../common/rpc/RequestBuilder";
+import {BatchDispatcher} from "./RequestTransmitter";
+import {ResponseCollector} from "./ResponseCollector";
 import MISSING_RESPONSE = ErrorMessage.Client.MISSING_RESPONSE;
 import UNKNOWN_STREAM_STATE = ErrorMessage.Client.UNKNOWN_STREAM_STATE;
 import ResCase = Transaction.ResPart.ResCase;
-import {BidirectionalStream} from "./BidirectionalStream";
 
 export class ResponsePartIterator implements AsyncIterable<Transaction.ResPart> {
 


### PR DESCRIPTION
## What is the goal of this PR?

Revert previous changes from https://github.com/vaticle/typedb-client-nodejs/pull/202, which made query queues and iterators throw the same error idempotently. However, this goes counter to standard usage of iterators and queues, which are not meant to behave idempotently (each item is only returned once, and if they have an error they should no longer be used). 

## What are the changes implemented in this PR?

* remove idempotent error state of collectors and queues, which back query iterators
  * note that we still store the error on the transaction bidirectional stream, in case the server throws an exception when there are no query iterators active
  

Note: mirrors change from https://github.com/vaticle/typedb-client-java/pull/372
