### PR TITLE
Extend concept type API

### DIFF
--- a/api/concept/type/AttributeType.ts
+++ b/api/concept/type/AttributeType.ts
@@ -74,6 +74,10 @@ export namespace AttributeType {
 
         getOwners(onlyKey: boolean): Stream<ThingType>;
 
+        getOwnersExplicit(): Stream<ThingType>;
+
+        getOwnersExplicit(onlyKey: boolean): Stream<ThingType>;
+
         asType(): Type.Remote;
 
         asThingType(): ThingType.Remote;

--- a/api/concept/type/RelationType.ts
+++ b/api/concept/type/RelationType.ts
@@ -76,6 +76,10 @@ export namespace RelationType {
 
         getRelates(roleLabel?: string): Promise<RoleType> | Stream<RoleType>;
 
+        getRelatesExplicit(): Stream<RoleType>;
+
+        getRelatesOverridden(roleLabel: string): Promise<RoleType>;
+
         setRelates(roleLabel: string, overriddenLabel?: string): Promise<void>;
 
         unsetRelates(roleLabel: string): Promise<void>;

--- a/api/concept/type/ThingType.ts
+++ b/api/concept/type/ThingType.ts
@@ -90,6 +90,8 @@ export namespace ThingType {
 
         getPlays(): Stream<RoleType>;
 
+        getPlaysExplicit(): Stream<RoleType>;
+
         getPlaysOverridden(role: RoleType): Promise<RoleType>;
 
         getOwns(): Stream<AttributeType>;

--- a/api/concept/type/ThingType.ts
+++ b/api/concept/type/ThingType.ts
@@ -90,6 +90,8 @@ export namespace ThingType {
 
         getPlays(): Stream<RoleType>;
 
+        getPlaysOverridden(role: RoleType): Promise<RoleType>;
+
         getOwns(): Stream<AttributeType>;
 
         getOwns(valueType: AttributeType.ValueType): Stream<AttributeType>;

--- a/api/concept/type/ThingType.ts
+++ b/api/concept/type/ThingType.ts
@@ -102,6 +102,16 @@ export namespace ThingType {
 
         getOwns(valueType: AttributeType.ValueType, keysOnly: boolean): Stream<AttributeType>;
 
+        getOwnsExplicit(): Stream<AttributeType>;
+
+        getOwnsExplicit(valueType: AttributeType.ValueType): Stream<AttributeType>;
+
+        getOwnsExplicit(keysOnly: boolean): Stream<AttributeType>;
+
+        getOwnsExplicit(valueType: AttributeType.ValueType, keysOnly: boolean): Stream<AttributeType>;
+
+        getOwnsOverridden(attributeType: AttributeType): Promise<AttributeType>;
+
         unsetPlays(role: RoleType): Promise<void>;
 
         unsetOwns(attributeType: AttributeType): Promise<void>;

--- a/common/rpc/RequestBuilder.ts
+++ b/common/rpc/RequestBuilder.ts
@@ -408,6 +408,12 @@ export namespace RequestBuilder {
                 ));
             }
 
+            export function getPlaysExplicitReq(label: Label) {
+                return typeReq(newReqBuilder(label).setThingTypeGetPlaysExplicitReq(
+                    new ThingTypeProto.GetPlaysExplicit.Req()
+                ));
+            }
+
             export function getPlaysOverriddenReq(label: Label) {
                 return typeReq(newReqBuilder(label).setThingTypeGetPlaysOverriddenReq(
                     new ThingTypeProto.GetPlaysOverridden.Req()

--- a/common/rpc/RequestBuilder.ts
+++ b/common/rpc/RequestBuilder.ts
@@ -550,6 +550,11 @@ export namespace RequestBuilder {
                     new AttributeTypeProto.GetOwners.Req().setOnlyKey(onlyKey)));
             }
 
+            export function getOwnersExplicitReq(label: Label, onlyKey: boolean) {
+                return typeReq(newReqBuilder(label).setAttributeTypeGetOwnersExplicitReq(
+                    new AttributeTypeProto.GetOwnersExplicit.Req().setOnlyKey(onlyKey)));
+            }
+
             export function putReq(label: Label, value: AttributeProto.Value) {
                 return typeReq(newReqBuilder(label).setAttributeTypePutReq(
                     new AttributeTypeProto.Put.Req().setValue(value)

--- a/common/rpc/RequestBuilder.ts
+++ b/common/rpc/RequestBuilder.ts
@@ -410,20 +410,20 @@ export namespace RequestBuilder {
 
             export function setPlaysReq(label: Label, roleType: TypeProto) {
                 return typeReq(newReqBuilder(label).setThingTypeSetPlaysReq(
-                    new ThingTypeProto.SetPlays.Req().setRole(roleType)
+                    new ThingTypeProto.SetPlays.Req().setRoleType(roleType)
                 ));
             }
 
             export function setPlaysOverriddenReq(label: Label, roleType: TypeProto, overriddenRoleType: TypeProto) {
                 return typeReq(newReqBuilder(label).setThingTypeSetPlaysReq(
-                    new ThingTypeProto.SetPlays.Req().setRole(roleType)
-                        .setOverriddenRole(overriddenRoleType)
+                    new ThingTypeProto.SetPlays.Req().setRoleType(roleType)
+                        .setOverriddenType(overriddenRoleType)
                 ));
             }
 
             export function unsetPlaysReq(label: Label, roleType: TypeProto) {
                 return typeReq(newReqBuilder(label).setThingTypeUnsetPlaysReq(
-                    new ThingTypeProto.UnsetPlays.Req().setRole(roleType)
+                    new ThingTypeProto.UnsetPlays.Req().setRoleType(roleType)
                 ));
             }
 
@@ -493,9 +493,21 @@ export namespace RequestBuilder {
                 ));
             }
 
+            export function getRelatesExplicitReq(label: Label) {
+                return typeReq(newReqBuilder(label).setRelationTypeGetRelatesExplicitReq(
+                    new RelationTypeProto.GetRelatesExplicit.Req()
+                ));
+            }
+
             export function getRelatesByRoleReq(label: Label, roleLabel: string) {
                 return typeReq(newReqBuilder(label).setRelationTypeGetRelatesForRoleLabelReq(
                     new RelationTypeProto.GetRelatesForRoleLabel.Req().setLabel(roleLabel)
+                ));
+            }
+
+            export function getRelatesOverridden(label: Label, roleLabel: string) {
+                return typeReq(newReqBuilder(label).setRelationTypeGetRelatesOverriddenReq(
+                    new RelationTypeProto.GetRelatesOverridden.Req().setLabel(roleLabel)
                 ));
             }
 

--- a/common/rpc/RequestBuilder.ts
+++ b/common/rpc/RequestBuilder.ts
@@ -452,6 +452,19 @@ export namespace RequestBuilder {
                 ));
             }
 
+            export function getOwnsExplicitReq(label: Label, keysOnly: boolean) {
+                return typeReq(newReqBuilder(label).setThingTypeGetOwnsExplicitReq(
+                    new ThingTypeProto.GetOwnsExplicit.Req().setKeysOnly(keysOnly)
+                ));
+            }
+
+            export function getOwnsExplicitByTypeReq(label: Label, valueType: AttributeTypeProto.ValueType, keysOnly: boolean) {
+                return typeReq(newReqBuilder(label).setThingTypeGetOwnsExplicitReq(
+                    new ThingTypeProto.GetOwnsExplicit.Req().setKeysOnly(keysOnly)
+                        .setValueType(valueType)
+                ));
+            }
+
             export function setOwnsReq(label: Label, attributeType: TypeProto, isKey: boolean) {
                 return typeReq(newReqBuilder(label).setThingTypeSetOwnsReq(
                     new ThingTypeProto.SetOwns.Req()
@@ -478,6 +491,12 @@ export namespace RequestBuilder {
             export function getInstancesReq(label: Label) {
                 return typeReq(newReqBuilder(label).setThingTypeGetInstancesReq(
                     new ThingTypeProto.GetInstances.Req()
+                ));
+            }
+
+            export function getOwnsOverriddenReq(label: Label, attributeType: TypeProto) {
+                return typeReq(newReqBuilder(label).setThingTypeGetOwnsOverriddenReq(
+                    new ThingTypeProto.GetOwnsOverridden.Req().setAttributeType(attributeType)
                 ));
             }
         }

--- a/common/rpc/RequestBuilder.ts
+++ b/common/rpc/RequestBuilder.ts
@@ -408,6 +408,12 @@ export namespace RequestBuilder {
                 ));
             }
 
+            export function getPlaysOverriddenReq(label: Label) {
+                return typeReq(newReqBuilder(label).setThingTypeGetPlaysOverriddenReq(
+                    new ThingTypeProto.GetPlaysOverridden.Req()
+                ));
+            }
+
             export function setPlaysReq(label: Label, roleType: TypeProto) {
                 return typeReq(newReqBuilder(label).setThingTypeSetPlaysReq(
                     new ThingTypeProto.SetPlays.Req().setRoleType(roleType)

--- a/concept/type/AttributeTypeImpl.ts
+++ b/concept/type/AttributeTypeImpl.ts
@@ -237,6 +237,13 @@ export namespace AttributeTypeImpl {
                 .map((thingTypeProto) => ThingTypeImpl.of(thingTypeProto));
         }
 
+        getOwnersExplicit(onlyKey?: boolean): Stream<ThingType> {
+            const request = RequestBuilder.Type.AttributeType.getOwnersExplicitReq(this.label, !!onlyKey);
+            return this.stream(request)
+                .flatMap((resPart) => Stream.array(resPart.getAttributeTypeGetOwnersExplicitResPart().getThingTypesList()))
+                .map((thingTypeProto) => ThingTypeImpl.of(thingTypeProto));
+        }
+
         protected getImpl(valueProto: AttributeProto.Value): Promise<Attribute> {
             const request = RequestBuilder.Type.AttributeType.getReq(this.label, valueProto);
             return this.execute(request)

--- a/concept/type/AttributeTypeImpl.ts
+++ b/concept/type/AttributeTypeImpl.ts
@@ -233,7 +233,7 @@ export namespace AttributeTypeImpl {
         getOwners(onlyKey?: boolean): Stream<ThingType> {
             const request = RequestBuilder.Type.AttributeType.getOwnersReq(this.label, !!onlyKey);
             return this.stream(request)
-                .flatMap((resPart) => Stream.array(resPart.getAttributeTypeGetOwnersResPart().getOwnersList()))
+                .flatMap((resPart) => Stream.array(resPart.getAttributeTypeGetOwnersResPart().getThingTypesList()))
                 .map((thingTypeProto) => ThingTypeImpl.of(thingTypeProto));
         }
 

--- a/concept/type/RelationTypeImpl.ts
+++ b/concept/type/RelationTypeImpl.ts
@@ -108,12 +108,29 @@ export namespace RelationTypeImpl {
                 const request = RequestBuilder.Type.RelationType.getRelatesReq(this.label);
                 return this.stream(request)
                     .flatMap((resPart) => {
-                        return Stream.array(resPart.getRelationTypeGetRelatesResPart().getRolesList())
+                        return Stream.array(resPart.getRelationTypeGetRelatesResPart().getRoleTypesList())
                     })
                     .map((roleProto) => {
                         return RoleTypeImpl.of(roleProto)
                     });
             }
+        }
+
+        getRelatesExplicit(): Stream<RoleType> {
+            const request = RequestBuilder.Type.RelationType.getRelatesExplicitReq(this.label);
+            return this.stream(request)
+                .flatMap((resPart) => {
+                    return Stream.array(resPart.getRelationTypeGetRelatesExplicitResPart().getRoleTypesList())
+                })
+                .map((roleProto) => {
+                    return RoleTypeImpl.of(roleProto)
+                });
+        }
+
+        async getRelatesOverridden(roleLabel: string): Promise<RoleType> {
+            const request = RequestBuilder.Type.RelationType.getRelatesOverridden(this.label, roleLabel);
+            return this.execute(request)
+                .then((res) => RoleTypeImpl.of(res.getRelationTypeGetRelatesOverriddenRes().getRoleType()));
         }
 
         async setRelates(roleLabel: string, overriddenLabel?: string): Promise<void> {

--- a/concept/type/ThingTypeImpl.ts
+++ b/concept/type/ThingTypeImpl.ts
@@ -139,6 +139,37 @@ export namespace ThingTypeImpl {
                 .map((attributeTypeProto) => AttributeTypeImpl.of(attributeTypeProto));
         }
 
+
+        getOwnsExplicit(): Stream<AttributeType>;
+        getOwnsExplicit(valueType: AttributeType.ValueType): Stream<AttributeType>;
+        getOwnsExplicit(keysOnly: boolean): Stream<AttributeType>;
+        getOwnsExplicit(valueType: AttributeType.ValueType, keysOnly: boolean): Stream<AttributeType>;
+        getOwnsExplicit(valueTypeOrKeysOnly?: AttributeType.ValueType | boolean, keysOnly?: boolean): Stream<AttributeType> {
+            let request;
+            if (!valueTypeOrKeysOnly) {
+                request = RequestBuilder.Type.ThingType.getOwnsExplicitReq(this.label, false);
+            } else if (typeof valueTypeOrKeysOnly === "boolean") {
+                request = RequestBuilder.Type.ThingType.getOwnsExplicitReq(this.label, valueTypeOrKeysOnly as boolean)
+            } else if (!keysOnly) {
+                request = RequestBuilder.Type.ThingType.getOwnsExplicitByTypeReq(
+                    this.label, (valueTypeOrKeysOnly as AttributeType.ValueType).proto(), false
+                );
+            } else {
+                request = RequestBuilder.Type.ThingType.getOwnsExplicitByTypeReq(
+                    this.label, (valueTypeOrKeysOnly as AttributeType.ValueType).proto(), keysOnly
+                );
+            }
+            return this.stream(request)
+                .flatMap((resPart) => Stream.array(resPart.getThingTypeGetOwnsExplicitResPart().getAttributeTypesList()))
+                .map((attributeTypeProto) => AttributeTypeImpl.of(attributeTypeProto));
+        }
+
+        async getOwnsOverridden(attributeType: AttributeType): Promise<AttributeType> {
+            let req = RequestBuilder.Type.ThingType.getOwnsOverriddenReq(this.label, ThingType.proto(attributeType));
+            return this.execute(req)
+                .then((res) => AttributeTypeImpl.of(res.getThingTypeGetOwnsOverriddenRes().getAttributeType()));
+        }
+
         async setOwns(attributeType: AttributeType): Promise<void>;
         async setOwns(attributeType: AttributeType, isKey: boolean): Promise<void>;
         async setOwns(attributeType: AttributeType, overriddenType: AttributeType): Promise<void>;

--- a/concept/type/ThingTypeImpl.ts
+++ b/concept/type/ThingTypeImpl.ts
@@ -172,6 +172,13 @@ export namespace ThingTypeImpl {
                 .map((roleProto) => RoleTypeImpl.of(roleProto));
         }
 
+        getPlaysExplicit(): Stream<RoleType> {
+            const request = RequestBuilder.Type.ThingType.getPlaysExplicitReq(this.label);
+            return this.stream(request)
+                .flatMap((resPart) => Stream.array(resPart.getThingTypeGetPlaysExplicitResPart().getRoleTypesList()))
+                .map((roleProto) => RoleTypeImpl.of(roleProto));
+        }
+
         async getPlaysOverridden(role: RoleType): Promise<RoleType> {
             const request = RequestBuilder.Type.ThingType.getPlaysOverriddenReq(this.label);
             return this.execute(request)

--- a/concept/type/ThingTypeImpl.ts
+++ b/concept/type/ThingTypeImpl.ts
@@ -165,7 +165,7 @@ export namespace ThingTypeImpl {
         }
 
         async getOwnsOverridden(attributeType: AttributeType): Promise<AttributeType> {
-            let req = RequestBuilder.Type.ThingType.getOwnsOverriddenReq(this.label, ThingType.proto(attributeType));
+            const req = RequestBuilder.Type.ThingType.getOwnsOverriddenReq(this.label, ThingType.proto(attributeType));
             return this.execute(req)
                 .then((res) => AttributeTypeImpl.of(res.getThingTypeGetOwnsOverriddenRes().getAttributeType()));
         }

--- a/concept/type/ThingTypeImpl.ts
+++ b/concept/type/ThingTypeImpl.ts
@@ -172,6 +172,12 @@ export namespace ThingTypeImpl {
                 .map((roleProto) => RoleTypeImpl.of(roleProto));
         }
 
+        async getPlaysOverridden(role: RoleType): Promise<RoleType> {
+            const request = RequestBuilder.Type.ThingType.getPlaysOverriddenReq(this.label);
+            return this.execute(request)
+                .then((res) => RoleTypeImpl.of(res.getThingTypeGetPlaysOverriddenRes().getRoleType()));
+        }
+
         async setPlays(role: RoleType): Promise<void>;
         async setPlays(role: RoleType, overriddenType?: RoleType): Promise<void> {
             let request;

--- a/concept/type/ThingTypeImpl.ts
+++ b/concept/type/ThingTypeImpl.ts
@@ -168,7 +168,7 @@ export namespace ThingTypeImpl {
         getPlays(): Stream<RoleType> {
             const request = RequestBuilder.Type.ThingType.getPlaysReq(this.label);
             return this.stream(request)
-                .flatMap((resPart) => Stream.array(resPart.getThingTypeGetPlaysResPart().getRolesList()))
+                .flatMap((resPart) => Stream.array(resPart.getThingTypeGetPlaysResPart().getRoleTypesList()))
                 .map((roleProto) => RoleTypeImpl.of(roleProto));
         }
 

--- a/dependencies/vaticle/artifacts.bzl
+++ b/dependencies/vaticle/artifacts.bzl
@@ -29,7 +29,7 @@ def vaticle_typedb_artifacts():
         artifact_name = "typedb-server-{platform}-{version}.{ext}",
         tag_source = deployment["artifact.release"],
         commit_source = deployment["artifact.snapshot"],
-        commit = "0f84e6577b6ef60dac838b604e6d66222c512957"
+        tag = "2.9.0"
     )
 
 def vaticle_typedb_cluster_artifacts():
@@ -39,5 +39,5 @@ def vaticle_typedb_cluster_artifacts():
         artifact_name = "typedb-cluster-all-{platform}-{version}.{ext}",
         tag_source = deployment_private["artifact.release"],
         commit_source = deployment_private["artifact.snapshot"],
-        commit = "aa8531f154d7c74c8922c71a252022c650c1be0c"
+        commit = "6eb5e84deffc55d06d7e205ba6414a647b247ada"
     )

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -33,12 +33,12 @@ def vaticle_typedb_common():
     git_repository(
         name = "vaticle_typedb_common",
         remote = "https://github.com/vaticle/typedb-common",
-        commit = "d11cee9745e4559450ef4ccb140d4e9781587932" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
+        tag = "2.9.0" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
     )
 
 def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
         remote = "https://github.com/vaticle/typedb-behaviour",
-        commit = "7aa405c01eb46b8a28867bc49c4f8c0427c32d52", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        commit = "184bc8a64aa69e383bf496c70b11f02201d33616", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@grpc/grpc-js": "1.5.0",
     "google-protobuf": "3.19.3",
-    "typedb-protocol": "2.6.1",
+    "typedb-protocol": "2.9.0",
     "uuid": "8.3.2"
   },
   "devDependencies": {

--- a/test/integration/test-concept.js
+++ b/test/integration/test-concept.js
@@ -208,7 +208,7 @@ async function run() {
         await person.asRemote(tx).setAbstract();
         await person.asRemote(tx).setOwns(email, true);
         man = await tx.concepts.getEntityType("man");
-        await man.asRemote(tx).setSupertype(tx.concepts.getRootEntityType());
+        await man.asRemote(tx).setSupertype(await tx.concepts.getRootEntityType());
         await person.asRemote(tx).setOwns(age, false);
         await lion.asRemote(tx).setOwns(age);
         customer = await tx.concepts.putEntityType("customer");
@@ -219,7 +219,7 @@ async function run() {
         const ownedDateTimes = await customer.asRemote(tx).getOwns(AttributeType.ValueType.DATETIME, false).collect();
         await tx.commit();
         await tx.close();
-        assert(ownedAttributes.length === 1);
+        assert(ownedAttributes.length === 2);
         assert(ownedKeys.length === 1);
         assert(ownedDateTimes.length === 0);
         console.log(`get/set owns, overriding a super-attribute - SUCCESS - 'customer' owns [${ownedAttributes.map(x => x.label.scopedName)}], ` +

--- a/test/integration/test-concept.js
+++ b/test/integration/test-concept.js
@@ -207,6 +207,8 @@ async function run() {
         age = await tx.concepts.putAttributeType("age", AttributeType.ValueType.LONG);
         await person.asRemote(tx).setAbstract();
         await person.asRemote(tx).setOwns(email, true);
+        man = await tx.concepts.getEntityType("man");
+        await man.asRemote(tx).setSupertype(tx.concepts.getRootEntityType());
         await person.asRemote(tx).setOwns(age, false);
         await lion.asRemote(tx).setOwns(age);
         customer = await tx.concepts.putEntityType("customer");
@@ -217,7 +219,7 @@ async function run() {
         const ownedDateTimes = await customer.asRemote(tx).getOwns(AttributeType.ValueType.DATETIME, false).collect();
         await tx.commit();
         await tx.close();
-        assert(ownedAttributes.length === 2);
+        assert(ownedAttributes.length === 1);
         assert(ownedKeys.length === 1);
         assert(ownedDateTimes.length === 0);
         console.log(`get/set owns, overriding a super-attribute - SUCCESS - 'customer' owns [${ownedAttributes.map(x => x.label.scopedName)}], ` +

--- a/yarn.lock
+++ b/yarn.lock
@@ -4246,10 +4246,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typedb-protocol@2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/typedb-protocol/-/typedb-protocol-2.6.1.tgz#402222e9a64d0f092903f2c07ae988471e92d1f1"
-  integrity sha512-zAfH3gJcxnHFgLe/vjuzoIldTYMEdmxT1ct6R+wMjzMveyF05pzZR4z5WVTJh+txN34A20zlpQPL2qzWeJISgg==
+typedb-protocol@2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/typedb-protocol/-/typedb-protocol-2.9.0.tgz#a523e5340bb2ab357353f120fc16fcd2dcaca8c8"
+  integrity sha512-73AHiCS8cGvaMKQ2XR/QOdH3hl/+De/KDiFqu2PEfl2NY1QauiP0lqIELZYIrimE+Ghk5CBCkEYS7t3sKBYHsw==
   dependencies:
     "@grpc/grpc-js" "1.5.0"
 


### PR DESCRIPTION
## What is the goal of this PR?

We catch up client-nodejs with the Java client version 2.9.0, which exposes an extended set of APIs on `Type`s.
We implement:
* `ThingType.getOwnsExplicit()` and `ThingType.getOwnsOverridden`
* `AttributeType.getOwnersExplicit()`
* `ThingType.getPlaysExplicit()`
* `ThingType.getPlaysOverridden()`
* `RelationType.getRelatesExplicit()` and `RelationType.getRelatesOverridden()`

## What are the changes implemented in this PR?

* Update `typedb-protocol` to version 2.9.0, and synchronise the naming conventions that were updated
* Implement Concept `Type` APIs that were missing, matching the requirements released in client-java 2.9.0
* Update any required changes in the lower-level packges to build requests