### PR TITLE
Fix deploy-npm-snapshot CI job

### DIFF
--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -153,7 +153,7 @@ build:
       filter:
         owner: vaticle
         branch: master
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-20.04
       dependencies: [
         build, test-integration,
         test-behaviour-connection-core,
@@ -165,10 +165,6 @@ build:
         test-behaviour-definable-core, test-behaviour-definable-cluster
       ]
       command: |
-        curl https://cli-assets.heroku.com/apt/release.key | sudo apt-key add -
-        wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
-        sudo apt update -y
-        sudo apt install -y expect
         export DEPLOY_NPM_TOKEN=$REPO_VATICLE_NPM_TOKEN
         bazel run --define version=$(git rev-parse HEAD) //:deploy-npm -- snapshot
     test-deployment-npm:


### PR DESCRIPTION
## What is the goal of this PR?

Fix the deploy-npm-snapshot Grabl CI job that was failing due to Ubuntu 21.04 repositories being archived. The Ubuntu image got downgraded to 20.04 LTS. Additionally, we found out that the installation of `expect` is not necessary.

## What are the changes implemented in this PR?

* Downgrade Ubuntu image to 20.04 for deploy-npm-snapshot CI job
* Remove lines related to installing the `expect` command
