### PR TITLE
Update to TypeDB 2.14 and add new RoleType methods and ThingType.getSyntax

### DIFF
--- a/api/concept/type/RoleType.ts
+++ b/api/concept/type/RoleType.ts
@@ -73,7 +73,17 @@ export namespace RoleType {
 
         getRelationTypes(): Stream<RelationType>;
 
-        getPlayers(): Stream<ThingType>;
+        getPlayerTypes(): Stream<ThingType>;
+
+        getPlayerTypesExplicit(): Stream<ThingType>;
+
+        getRelationInstances(): Stream<Relation>;
+
+        getRelationInstancesExplicit(): Stream<Relation>;
+
+        getPlayerInstances(): Stream<Thing>;
+
+        getPlayerInstancesExplicit(): Stream<Thing>;
     }
 
     export function proto(roleType: RoleType) {

--- a/api/concept/type/ThingType.ts
+++ b/api/concept/type/ThingType.ts
@@ -115,6 +115,8 @@ export namespace ThingType {
         unsetPlays(role: RoleType): Promise<void>;
 
         unsetOwns(attributeType: AttributeType): Promise<void>;
+
+        getSyntax(): Promise<string>;
     }
 
     export function proto(thingType: ThingType) {

--- a/api/concept/type/Type.ts
+++ b/api/concept/type/Type.ts
@@ -44,6 +44,8 @@ export interface Type extends Concept {
 
     readonly root: boolean;
 
+    readonly abstract: boolean;
+
     asRemote(transaction: TypeDBTransaction): Type.Remote;
 }
 
@@ -74,8 +76,6 @@ export namespace Type {
         asRelation(): Relation.Remote;
 
         setLabel(label: string): Promise<void>;
-
-        isAbstract(): Promise<boolean>;
 
         getSupertype(): Promise<Type>;
 

--- a/common/rpc/RequestBuilder.ts
+++ b/common/rpc/RequestBuilder.ts
@@ -323,12 +323,6 @@ export namespace RequestBuilder {
             return builder;
         }
 
-        export function isAbstractReq(label: Label) {
-            return typeReq(newReqBuilder(label).setTypeIsAbstractReq(
-                new TypeProto.IsAbstract.Req()
-            ));
-        }
-
         export function setLabelReq(label: Label, newLabel: string) {
             return typeReq(newReqBuilder(label).setTypeSetLabelReq(
                 new TypeProto.SetLabel.Req().setLabel(newLabel)
@@ -371,9 +365,39 @@ export namespace RequestBuilder {
                 ));
             }
 
-            export function getPlayersReq(label: Label) {
-                return typeReq(newReqBuilder(label).setRoleTypeGetPlayersReq(
-                    new RoleTypeProto.GetPlayers.Req()
+            export function getPlayerTypesReq(label: Label) {
+                return typeReq(newReqBuilder(label).setRoleTypeGetPlayerTypesReq(
+                    new RoleTypeProto.GetPlayerTypes.Req()
+                ));
+            }
+
+            export function getPlayerTypesExplicitReq(label: Label) {
+                return typeReq(newReqBuilder(label).setRoleTypeGetPlayerTypesExplicitReq(
+                    new RoleTypeProto.GetPlayerTypesExplicit.Req()
+                ));
+            }
+
+            export function getRelationInstancesReq(label: Label) {
+                return typeReq(newReqBuilder(label).setRoleTypeGetRelationInstancesReq(
+                    new RoleTypeProto.GetRelationInstances.Req()
+                ));
+            }
+
+            export function getRelationInstancesExplicitReq(label: Label) {
+                return typeReq(newReqBuilder(label).setRoleTypeGetRelationInstancesExplicitReq(
+                    new RoleTypeProto.GetRelationInstancesExplicit.Req()
+                ));
+            }
+
+            export function getPlayerInstancesReq(label: Label) {
+                return typeReq(newReqBuilder(label).setRoleTypeGetPlayerInstancesReq(
+                    new RoleTypeProto.GetPlayerInstances.Req()
+                ));
+            }
+
+            export function getPlayerInstancesExplicitReq(label: Label) {
+                return typeReq(newReqBuilder(label).setRoleTypeGetPlayerInstancesExplicitReq(
+                    new RoleTypeProto.GetPlayerInstancesExplicit.Req()
                 ));
             }
         }
@@ -498,6 +522,10 @@ export namespace RequestBuilder {
                 return typeReq(newReqBuilder(label).setThingTypeGetOwnsOverriddenReq(
                     new ThingTypeProto.GetOwnsOverridden.Req().setAttributeType(attributeType)
                 ));
+            }
+
+            export function getSyntaxReq(label: Label) {
+                return typeReq(newReqBuilder(label).setThingTypeGetSyntaxReq(new ThingTypeProto.GetSyntax.Req()));
             }
         }
 

--- a/concept/type/AttributeTypeImpl.ts
+++ b/concept/type/AttributeTypeImpl.ts
@@ -36,8 +36,8 @@ import INVALID_CONCEPT_CASTING = ErrorMessage.Concept.INVALID_CONCEPT_CASTING;
 
 export class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
 
-    constructor(name: string, root: boolean) {
-        super(name, root);
+    constructor(name: string, root: boolean, abstract: boolean) {
+        super(name, root, abstract);
     }
 
     protected get className(): string {
@@ -45,7 +45,7 @@ export class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
     }
 
     asRemote(transaction: TypeDBTransaction): AttributeType.Remote {
-        return new AttributeTypeImpl.Remote(transaction as TypeDBTransaction.Extended, this.label, this.root);
+        return new AttributeTypeImpl.Remote(transaction as TypeDBTransaction.Extended, this.label, this.root, this.abstract);
     }
 
     get valueType(): AttributeType.ValueType {
@@ -82,35 +82,35 @@ export class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
 
     asBoolean(): AttributeType.Boolean {
         if (this.root) {
-            return new AttributeTypeImpl.Boolean(this.label.name, this.root);
+            return new AttributeTypeImpl.Boolean(this.label.name, this.root, this.abstract);
         }
         throw new TypeDBClientError(INVALID_CONCEPT_CASTING.message(this.className, "AttributeType.Boolean"));
     }
 
     asLong(): AttributeType.Long {
         if (this.root) {
-            return new AttributeTypeImpl.Long(this.label.name, this.root);
+            return new AttributeTypeImpl.Long(this.label.name, this.root, this.abstract);
         }
         throw new TypeDBClientError(INVALID_CONCEPT_CASTING.message(this.className, "AttributeType.Long"));
     }
 
     asDouble(): AttributeType.Double {
         if (this.root) {
-            return new AttributeTypeImpl.Double(this.label.name, this.root);
+            return new AttributeTypeImpl.Double(this.label.name, this.root, this.abstract);
         }
         throw new TypeDBClientError(INVALID_CONCEPT_CASTING.message(this.className, "AttributeType.Double"));
     }
 
     asString(): AttributeType.String {
         if (this.root) {
-            return new AttributeTypeImpl.String(this.label.name, this.root);
+            return new AttributeTypeImpl.String(this.label.name, this.root, this.abstract);
         }
         throw new TypeDBClientError(INVALID_CONCEPT_CASTING.message(this.className, "AttributeType.String"));
     }
 
     asDateTime(): AttributeType.DateTime {
         if (this.root) {
-            return new AttributeTypeImpl.DateTime(this.label.name, this.root);
+            return new AttributeTypeImpl.DateTime(this.label.name, this.root, this.abstract);
         }
         throw new TypeDBClientError(INVALID_CONCEPT_CASTING.message(this.className, "AttributeType.DateTime"));
     }
@@ -122,17 +122,17 @@ export namespace AttributeTypeImpl {
         if (!attributeTypeProto) return null;
         switch (attributeTypeProto.getValueType()) {
             case AttributeTypeProto.ValueType.BOOLEAN:
-                return new AttributeTypeImpl.Boolean(attributeTypeProto.getLabel(), attributeTypeProto.getRoot());
+                return new AttributeTypeImpl.Boolean(attributeTypeProto.getLabel(), attributeTypeProto.getIsroot(), attributeTypeProto.getIsabstract());
             case AttributeTypeProto.ValueType.LONG:
-                return new AttributeTypeImpl.Long(attributeTypeProto.getLabel(), attributeTypeProto.getRoot());
+                return new AttributeTypeImpl.Long(attributeTypeProto.getLabel(), attributeTypeProto.getIsroot(), attributeTypeProto.getIsabstract());
             case AttributeTypeProto.ValueType.DOUBLE:
-                return new AttributeTypeImpl.Double(attributeTypeProto.getLabel(), attributeTypeProto.getRoot());
+                return new AttributeTypeImpl.Double(attributeTypeProto.getLabel(), attributeTypeProto.getIsroot(), attributeTypeProto.getIsabstract());
             case AttributeTypeProto.ValueType.STRING:
-                return new AttributeTypeImpl.String(attributeTypeProto.getLabel(), attributeTypeProto.getRoot());
+                return new AttributeTypeImpl.String(attributeTypeProto.getLabel(), attributeTypeProto.getIsroot(), attributeTypeProto.getIsabstract());
             case AttributeTypeProto.ValueType.DATETIME:
-                return new AttributeTypeImpl.DateTime(attributeTypeProto.getLabel(), attributeTypeProto.getRoot());
+                return new AttributeTypeImpl.DateTime(attributeTypeProto.getLabel(), attributeTypeProto.getIsroot(), attributeTypeProto.getIsabstract());
             case AttributeTypeProto.ValueType.OBJECT:
-                return new AttributeTypeImpl(attributeTypeProto.getLabel(), attributeTypeProto.getRoot());
+                return new AttributeTypeImpl(attributeTypeProto.getLabel(), attributeTypeProto.getIsroot(), attributeTypeProto.getIsabstract());
             default:
                 throw new TypeDBClientError(BAD_VALUE_TYPE.message(attributeTypeProto.getValueType()));
         }
@@ -140,8 +140,8 @@ export namespace AttributeTypeImpl {
 
     export class Remote extends ThingTypeImpl.Remote implements AttributeType.Remote {
 
-        constructor(transaction: TypeDBTransaction.Extended, label: Label, root: boolean) {
-            super(transaction, label, root);
+        constructor(transaction: TypeDBTransaction.Extended, label: Label, root: boolean, abstract: boolean) {
+            super(transaction, label, root, abstract);
         }
 
         protected get className(): string {
@@ -149,7 +149,7 @@ export namespace AttributeTypeImpl {
         }
 
         asRemote(transaction: TypeDBTransaction): AttributeType.Remote {
-            return new AttributeTypeImpl.Remote(transaction as TypeDBTransaction.Extended, this.label, this.root);
+            return new AttributeTypeImpl.Remote(transaction as TypeDBTransaction.Extended, this.label, this.root, this.abstract);
         }
 
         get valueType(): AttributeType.ValueType {
@@ -186,35 +186,35 @@ export namespace AttributeTypeImpl {
 
         asBoolean(): AttributeType.Boolean.Remote {
             if (this.root) {
-                return new AttributeTypeImpl.Boolean.Remote(this.transaction, this.label, this.root);
+                return new AttributeTypeImpl.Boolean.Remote(this.transaction, this.label, this.root, this.abstract);
             }
             throw new TypeDBClientError(INVALID_CONCEPT_CASTING.message(this.className, "AttributeType.Boolean"));
         }
 
         asLong(): AttributeType.Long.Remote {
             if (this.root) {
-                return new AttributeTypeImpl.Long.Remote(this.transaction, this.label, this.root);
+                return new AttributeTypeImpl.Long.Remote(this.transaction, this.label, this.root, this.abstract);
             }
             throw new TypeDBClientError(INVALID_CONCEPT_CASTING.message(this.className, "AttributeType.Long"));
         }
 
         asDouble(): AttributeType.Double.Remote {
             if (this.root) {
-                return new AttributeTypeImpl.Double.Remote(this.transaction, this.label, this.root);
+                return new AttributeTypeImpl.Double.Remote(this.transaction, this.label, this.root, this.abstract);
             }
             throw new TypeDBClientError(INVALID_CONCEPT_CASTING.message(this.className, "AttributeType.Double"));
         }
 
         asString(): AttributeType.String.Remote {
             if (this.root) {
-                return new AttributeTypeImpl.String.Remote(this.transaction, this.label, this.root);
+                return new AttributeTypeImpl.String.Remote(this.transaction, this.label, this.root, this.abstract);
             }
             throw new TypeDBClientError(INVALID_CONCEPT_CASTING.message(this.className, "AttributeType.String"));
         }
 
         asDateTime(): AttributeType.DateTime.Remote {
             if (this.root) {
-                return new AttributeTypeImpl.DateTime.Remote(this.transaction, this.label, this.root);
+                return new AttributeTypeImpl.DateTime.Remote(this.transaction, this.label, this.root, this.abstract);
             }
             throw new TypeDBClientError(INVALID_CONCEPT_CASTING.message(this.className, "AttributeType.DateTime"));
         }
@@ -254,8 +254,8 @@ export namespace AttributeTypeImpl {
 
     export class Boolean extends AttributeTypeImpl implements AttributeType.Boolean {
 
-        constructor(label: string, root: boolean) {
-            super(label, root);
+        constructor(label: string, root: boolean, abstract: boolean) {
+            super(label, root, abstract);
         }
 
         protected get className(): string {
@@ -263,7 +263,7 @@ export namespace AttributeTypeImpl {
         }
 
         asRemote(transaction: TypeDBTransaction): AttributeType.Boolean.Remote {
-            return new AttributeTypeImpl.Boolean.Remote(transaction as TypeDBTransaction.Extended, this.label, this.root);
+            return new AttributeTypeImpl.Boolean.Remote(transaction as TypeDBTransaction.Extended, this.label, this.root, this.abstract);
         }
 
         get valueType(): AttributeType.ValueType {
@@ -283,8 +283,8 @@ export namespace AttributeTypeImpl {
 
         export class Remote extends AttributeTypeImpl.Remote implements AttributeType.Boolean.Remote {
 
-            constructor(transaction: TypeDBTransaction.Extended, label: Label, root: boolean) {
-                super(transaction, label, root);
+            constructor(transaction: TypeDBTransaction.Extended, label: Label, root: boolean, abstract: boolean) {
+                super(transaction, label, root, abstract);
             }
 
             protected get className(): string {
@@ -292,7 +292,7 @@ export namespace AttributeTypeImpl {
             }
 
             asRemote(transaction: TypeDBTransaction): AttributeType.Boolean.Remote {
-                return new AttributeTypeImpl.Boolean.Remote(transaction as TypeDBTransaction.Extended, this.label, this.root);
+                return new AttributeTypeImpl.Boolean.Remote(transaction as TypeDBTransaction.Extended, this.label, this.root, this.abstract);
             }
 
             get valueType(): AttributeType.ValueType {
@@ -328,8 +328,8 @@ export namespace AttributeTypeImpl {
 
     export class Long extends AttributeTypeImpl implements AttributeType.Long {
 
-        constructor(label: string, root: boolean) {
-            super(label, root);
+        constructor(label: string, root: boolean, abstract: boolean) {
+            super(label, root, abstract);
         }
 
         protected get className(): string {
@@ -337,7 +337,7 @@ export namespace AttributeTypeImpl {
         }
 
         asRemote(transaction: TypeDBTransaction): AttributeType.Long.Remote {
-            return new AttributeTypeImpl.Long.Remote(transaction as TypeDBTransaction.Extended, this.label, this.root);
+            return new AttributeTypeImpl.Long.Remote(transaction as TypeDBTransaction.Extended, this.label, this.root, this.abstract);
         }
 
         get valueType(): AttributeType.ValueType {
@@ -357,8 +357,8 @@ export namespace AttributeTypeImpl {
 
         export class Remote extends AttributeTypeImpl.Remote implements AttributeType.Long.Remote {
 
-            constructor(transaction: TypeDBTransaction.Extended, label: Label, root: boolean) {
-                super(transaction, label, root);
+            constructor(transaction: TypeDBTransaction.Extended, label: Label, root: boolean, abstract: boolean) {
+                super(transaction, label, root, abstract);
             }
 
             protected get className(): string {
@@ -366,7 +366,7 @@ export namespace AttributeTypeImpl {
             }
 
             asRemote(transaction: TypeDBTransaction): AttributeType.Long.Remote {
-                return new AttributeTypeImpl.Long.Remote(transaction as TypeDBTransaction.Extended, this.label, this.root);
+                return new AttributeTypeImpl.Long.Remote(transaction as TypeDBTransaction.Extended, this.label, this.root, this.abstract);
             }
 
             get valueType(): AttributeType.ValueType {
@@ -402,8 +402,8 @@ export namespace AttributeTypeImpl {
 
     export class Double extends AttributeTypeImpl implements AttributeType.Double {
 
-        constructor(label: string, root: boolean) {
-            super(label, root);
+        constructor(label: string, root: boolean, abstract: boolean) {
+            super(label, root, abstract);
         }
 
         protected get className(): string {
@@ -411,7 +411,7 @@ export namespace AttributeTypeImpl {
         }
 
         asRemote(transaction: TypeDBTransaction): AttributeType.Double.Remote {
-            return new AttributeTypeImpl.Double.Remote(transaction as TypeDBTransaction.Extended, this.label, this.root);
+            return new AttributeTypeImpl.Double.Remote(transaction as TypeDBTransaction.Extended, this.label, this.root, this.abstract);
         }
 
         get valueType(): AttributeType.ValueType {
@@ -431,8 +431,8 @@ export namespace AttributeTypeImpl {
 
         export class Remote extends AttributeTypeImpl.Remote implements AttributeType.Double.Remote {
 
-            constructor(transaction: TypeDBTransaction.Extended, label: Label, root: boolean) {
-                super(transaction, label, root);
+            constructor(transaction: TypeDBTransaction.Extended, label: Label, root: boolean, abstract: boolean) {
+                super(transaction, label, root, abstract);
             }
 
             protected get className(): string {
@@ -440,7 +440,7 @@ export namespace AttributeTypeImpl {
             }
 
             asRemote(transaction: TypeDBTransaction): AttributeType.Double.Remote {
-                return new AttributeTypeImpl.Double.Remote(transaction as TypeDBTransaction.Extended, this.label, this.root);
+                return new AttributeTypeImpl.Double.Remote(transaction as TypeDBTransaction.Extended, this.label, this.root, this.abstract);
             }
 
             get valueType(): AttributeType.ValueType {
@@ -476,8 +476,8 @@ export namespace AttributeTypeImpl {
 
     export class String extends AttributeTypeImpl implements AttributeType.String {
 
-        constructor(label: string, root: boolean) {
-            super(label, root);
+        constructor(label: string, root: boolean, abstract: boolean) {
+            super(label, root, abstract);
         }
 
         protected get className(): string {
@@ -485,7 +485,7 @@ export namespace AttributeTypeImpl {
         }
 
         asRemote(transaction: TypeDBTransaction): AttributeType.String.Remote {
-            return new AttributeTypeImpl.String.Remote(transaction as TypeDBTransaction.Extended, this.label, this.root)
+            return new AttributeTypeImpl.String.Remote(transaction as TypeDBTransaction.Extended, this.label, this.root, this.abstract)
         }
 
         get valueType(): AttributeType.ValueType {
@@ -505,8 +505,8 @@ export namespace AttributeTypeImpl {
 
         export class Remote extends AttributeTypeImpl.Remote implements AttributeType.String.Remote {
 
-            constructor(transaction: TypeDBTransaction.Extended, label: Label, root: boolean) {
-                super(transaction, label, root);
+            constructor(transaction: TypeDBTransaction.Extended, label: Label, root: boolean, abstract: boolean) {
+                super(transaction, label, root, abstract);
             }
 
             protected get className(): string {
@@ -514,7 +514,7 @@ export namespace AttributeTypeImpl {
             }
 
             asRemote(transaction: TypeDBTransaction): AttributeType.String.Remote {
-                return new AttributeTypeImpl.String.Remote(transaction as TypeDBTransaction.Extended, this.label, this.root)
+                return new AttributeTypeImpl.String.Remote(transaction as TypeDBTransaction.Extended, this.label, this.root, this.abstract)
             }
 
             get valueType(): AttributeType.ValueType {
@@ -560,8 +560,8 @@ export namespace AttributeTypeImpl {
 
     export class DateTime extends AttributeTypeImpl implements AttributeType.DateTime {
 
-        constructor(label: string, root: boolean) {
-            super(label, root);
+        constructor(label: string, root: boolean, abstract: boolean) {
+            super(label, root, abstract);
         }
 
         protected get className(): string {
@@ -569,7 +569,7 @@ export namespace AttributeTypeImpl {
         }
 
         asRemote(transaction: TypeDBTransaction): AttributeType.DateTime.Remote {
-            return new AttributeTypeImpl.DateTime.Remote(transaction as TypeDBTransaction.Extended, this.label, this.root);
+            return new AttributeTypeImpl.DateTime.Remote(transaction as TypeDBTransaction.Extended, this.label, this.root, this.abstract);
         }
 
         get valueType(): AttributeType.ValueType {
@@ -589,8 +589,8 @@ export namespace AttributeTypeImpl {
 
         export class Remote extends AttributeTypeImpl.Remote implements AttributeType.DateTime.Remote {
 
-            constructor(transaction: TypeDBTransaction.Extended, label: Label, root: boolean) {
-                super(transaction, label, root);
+            constructor(transaction: TypeDBTransaction.Extended, label: Label, root: boolean, abstract: boolean) {
+                super(transaction, label, root, abstract);
             }
 
             protected get className(): string {
@@ -598,7 +598,7 @@ export namespace AttributeTypeImpl {
             }
 
             asRemote(transaction: TypeDBTransaction): AttributeType.DateTime.Remote {
-                return new AttributeTypeImpl.DateTime.Remote(transaction as TypeDBTransaction.Extended, this.label, this.root);
+                return new AttributeTypeImpl.DateTime.Remote(transaction as TypeDBTransaction.Extended, this.label, this.root, this.abstract);
             }
 
             get valueType(): AttributeType.ValueType {

--- a/concept/type/AttributeTypeImpl.ts
+++ b/concept/type/AttributeTypeImpl.ts
@@ -122,17 +122,17 @@ export namespace AttributeTypeImpl {
         if (!attributeTypeProto) return null;
         switch (attributeTypeProto.getValueType()) {
             case AttributeTypeProto.ValueType.BOOLEAN:
-                return new AttributeTypeImpl.Boolean(attributeTypeProto.getLabel(), attributeTypeProto.getIsroot(), attributeTypeProto.getIsabstract());
+                return new AttributeTypeImpl.Boolean(attributeTypeProto.getLabel(), attributeTypeProto.getIsRoot(), attributeTypeProto.getIsAbstract());
             case AttributeTypeProto.ValueType.LONG:
-                return new AttributeTypeImpl.Long(attributeTypeProto.getLabel(), attributeTypeProto.getIsroot(), attributeTypeProto.getIsabstract());
+                return new AttributeTypeImpl.Long(attributeTypeProto.getLabel(), attributeTypeProto.getIsRoot(), attributeTypeProto.getIsAbstract());
             case AttributeTypeProto.ValueType.DOUBLE:
-                return new AttributeTypeImpl.Double(attributeTypeProto.getLabel(), attributeTypeProto.getIsroot(), attributeTypeProto.getIsabstract());
+                return new AttributeTypeImpl.Double(attributeTypeProto.getLabel(), attributeTypeProto.getIsRoot(), attributeTypeProto.getIsAbstract());
             case AttributeTypeProto.ValueType.STRING:
-                return new AttributeTypeImpl.String(attributeTypeProto.getLabel(), attributeTypeProto.getIsroot(), attributeTypeProto.getIsabstract());
+                return new AttributeTypeImpl.String(attributeTypeProto.getLabel(), attributeTypeProto.getIsRoot(), attributeTypeProto.getIsAbstract());
             case AttributeTypeProto.ValueType.DATETIME:
-                return new AttributeTypeImpl.DateTime(attributeTypeProto.getLabel(), attributeTypeProto.getIsroot(), attributeTypeProto.getIsabstract());
+                return new AttributeTypeImpl.DateTime(attributeTypeProto.getLabel(), attributeTypeProto.getIsRoot(), attributeTypeProto.getIsAbstract());
             case AttributeTypeProto.ValueType.OBJECT:
-                return new AttributeTypeImpl(attributeTypeProto.getLabel(), attributeTypeProto.getIsroot(), attributeTypeProto.getIsabstract());
+                return new AttributeTypeImpl(attributeTypeProto.getLabel(), attributeTypeProto.getIsRoot(), attributeTypeProto.getIsAbstract());
             default:
                 throw new TypeDBClientError(BAD_VALUE_TYPE.message(attributeTypeProto.getValueType()));
         }

--- a/concept/type/EntityTypeImpl.ts
+++ b/concept/type/EntityTypeImpl.ts
@@ -30,8 +30,8 @@ import { EntityImpl, ThingTypeImpl } from "../../dependencies_internal";
 
 export class EntityTypeImpl extends ThingTypeImpl implements EntityType {
 
-    constructor(name: string, root: boolean) {
-        super(name, root);
+    constructor(name: string, root: boolean, abstract: boolean) {
+        super(name, root, abstract);
     }
 
     protected get className(): string {
@@ -39,7 +39,7 @@ export class EntityTypeImpl extends ThingTypeImpl implements EntityType {
     }
 
     asRemote(transaction: TypeDBTransaction): EntityType.Remote {
-        return new EntityTypeImpl.Remote(transaction as TypeDBTransaction.Extended, this.label, this.root);
+        return new EntityTypeImpl.Remote(transaction as TypeDBTransaction.Extended, this.label, this.root, this.abstract);
     }
 
     isEntityType(): boolean {
@@ -55,13 +55,13 @@ export namespace EntityTypeImpl {
 
     export function of(entityTypeProto: TypeProto) {
         if (!entityTypeProto) return null;
-        return new EntityTypeImpl(entityTypeProto.getLabel(), entityTypeProto.getRoot());
+        return new EntityTypeImpl(entityTypeProto.getLabel(), entityTypeProto.getIsroot(), entityTypeProto.getIsabstract());
     }
 
     export class Remote extends ThingTypeImpl.Remote implements EntityType.Remote {
 
-        constructor(transaction: TypeDBTransaction.Extended, label: Label, root: boolean) {
-            super(transaction, label, root);
+        constructor(transaction: TypeDBTransaction.Extended, label: Label, root: boolean, abstract: boolean) {
+            super(transaction, label, root, abstract);
         }
 
         protected get className(): string {
@@ -69,7 +69,7 @@ export namespace EntityTypeImpl {
         }
 
         asRemote(transaction: TypeDBTransaction): EntityType.Remote {
-            return new EntityTypeImpl.Remote(transaction as TypeDBTransaction.Extended, this.label, this.root);
+            return new EntityTypeImpl.Remote(transaction as TypeDBTransaction.Extended, this.label, this.root, this.abstract);
         }
 
         isEntityType(): boolean {

--- a/concept/type/EntityTypeImpl.ts
+++ b/concept/type/EntityTypeImpl.ts
@@ -55,7 +55,7 @@ export namespace EntityTypeImpl {
 
     export function of(entityTypeProto: TypeProto) {
         if (!entityTypeProto) return null;
-        return new EntityTypeImpl(entityTypeProto.getLabel(), entityTypeProto.getIsroot(), entityTypeProto.getIsabstract());
+        return new EntityTypeImpl(entityTypeProto.getLabel(), entityTypeProto.getIsRoot(), entityTypeProto.getIsAbstract());
     }
 
     export class Remote extends ThingTypeImpl.Remote implements EntityType.Remote {

--- a/concept/type/RelationTypeImpl.ts
+++ b/concept/type/RelationTypeImpl.ts
@@ -56,7 +56,7 @@ export namespace RelationTypeImpl {
 
     export function of(relationTypeProto: TypeProto) {
         if (!relationTypeProto) return null;
-        return new RelationTypeImpl(relationTypeProto.getLabel(), relationTypeProto.getIsroot(), relationTypeProto.getIsabstract());
+        return new RelationTypeImpl(relationTypeProto.getLabel(), relationTypeProto.getIsRoot(), relationTypeProto.getIsAbstract());
     }
 
     export class Remote extends ThingTypeImpl.Remote implements RelationType.Remote {

--- a/concept/type/RelationTypeImpl.ts
+++ b/concept/type/RelationTypeImpl.ts
@@ -31,8 +31,8 @@ import { RelationImpl, RoleTypeImpl, ThingTypeImpl } from "../../dependencies_in
 
 export class RelationTypeImpl extends ThingTypeImpl implements RelationType {
 
-    constructor(label: string, root: boolean) {
-        super(label, root);
+    constructor(label: string, root: boolean, abstract: boolean) {
+        super(label, root, abstract);
     }
 
     protected get className(): string {
@@ -40,7 +40,7 @@ export class RelationTypeImpl extends ThingTypeImpl implements RelationType {
     }
 
     asRemote(transaction: TypeDBTransaction): RelationType.Remote {
-        return new RelationTypeImpl.Remote(transaction as TypeDBTransaction.Extended, this.label, this.root);
+        return new RelationTypeImpl.Remote(transaction as TypeDBTransaction.Extended, this.label, this.root, this.abstract);
     }
 
     isRelationType(): boolean {
@@ -56,13 +56,13 @@ export namespace RelationTypeImpl {
 
     export function of(relationTypeProto: TypeProto) {
         if (!relationTypeProto) return null;
-        return new RelationTypeImpl(relationTypeProto.getLabel(), relationTypeProto.getRoot());
+        return new RelationTypeImpl(relationTypeProto.getLabel(), relationTypeProto.getIsroot(), relationTypeProto.getIsabstract());
     }
 
     export class Remote extends ThingTypeImpl.Remote implements RelationType.Remote {
 
-        constructor(transaction: TypeDBTransaction.Extended, label: Label, root: boolean) {
-            super(transaction, label, root);
+        constructor(transaction: TypeDBTransaction.Extended, label: Label, root: boolean, abstract: boolean) {
+            super(transaction, label, root, abstract);
         }
 
         protected get className(): string {
@@ -70,7 +70,7 @@ export namespace RelationTypeImpl {
         }
 
         asRemote(transaction: TypeDBTransaction): RelationType.Remote {
-            return new RelationTypeImpl.Remote(transaction as TypeDBTransaction.Extended, this.label, this.root);
+            return new RelationTypeImpl.Remote(transaction as TypeDBTransaction.Extended, this.label, this.root, this.abstract);
         }
 
         isRelationType(): boolean {

--- a/concept/type/RoleTypeImpl.ts
+++ b/concept/type/RoleTypeImpl.ts
@@ -20,6 +20,8 @@
  */
 
 import { Type as TypeProto } from "typedb-protocol/common/concept_pb";
+import { Relation } from "../../api/concept/thing/Relation";
+import { Thing } from "../../api/concept/thing/Thing";
 import { RelationType } from "../../api/concept/type/RelationType";
 import { RoleType } from "../../api/concept/type/RoleType";
 import { ThingType } from "../../api/concept/type/ThingType";
@@ -27,12 +29,12 @@ import { TypeDBTransaction } from "../../api/connection/TypeDBTransaction";
 import { Label } from "../../common/Label";
 import { RequestBuilder } from "../../common/rpc/RequestBuilder";
 import { Stream } from "../../common/util/Stream";
-import { RelationTypeImpl, ThingTypeImpl, TypeImpl } from "../../dependencies_internal";
+import { RelationImpl, RelationTypeImpl, ThingImpl, ThingTypeImpl, TypeImpl } from "../../dependencies_internal";
 
 export class RoleTypeImpl extends TypeImpl implements RoleType {
 
-    constructor(scope: string, label: string, root: boolean) {
-        super(Label.scoped(scope, label), root);
+    constructor(scope: string, label: string, root: boolean, abstract: boolean) {
+        super(Label.scoped(scope, label), root, abstract);
     }
 
     protected get className(): string {
@@ -40,7 +42,7 @@ export class RoleTypeImpl extends TypeImpl implements RoleType {
     }
 
     asRemote(transaction: TypeDBTransaction): RoleType.Remote {
-        return new RoleTypeImpl.Remote(transaction as TypeDBTransaction.Extended, this.label, this.root);
+        return new RoleTypeImpl.Remote(transaction as TypeDBTransaction.Extended, this.label, this.root, this.abstract);
     }
 
     isRoleType(): boolean {
@@ -56,13 +58,13 @@ export namespace RoleTypeImpl {
 
     export function of(typeProto: TypeProto) {
         if (!typeProto) return null;
-        return new RoleTypeImpl(typeProto.getScope(), typeProto.getLabel(), typeProto.getRoot());
+        return new RoleTypeImpl(typeProto.getScope(), typeProto.getLabel(), typeProto.getIsroot(), typeProto.getIsabstract());
     }
 
     export class Remote extends TypeImpl.Remote implements RoleType.Remote {
 
-        constructor(transaction: TypeDBTransaction.Extended, label: Label, root: boolean) {
-            super(transaction, label, root);
+        constructor(transaction: TypeDBTransaction.Extended, label: Label, root: boolean, abstract: boolean) {
+            super(transaction, label, root, abstract);
         }
 
         protected get className(): string {
@@ -70,7 +72,7 @@ export namespace RoleTypeImpl {
         }
 
         asRemote(transaction: TypeDBTransaction): RoleType.Remote {
-            return new RoleTypeImpl.Remote(transaction as TypeDBTransaction.Extended, this.label, this.root);
+            return new RoleTypeImpl.Remote(transaction as TypeDBTransaction.Extended, this.label, this.root, this.abstract);
         }
 
         isRoleType(): boolean {
@@ -104,11 +106,46 @@ export namespace RoleTypeImpl {
                 .map((res) => RelationTypeImpl.of(res));
         }
 
-        getPlayers(): Stream<ThingType> {
-            const request = RequestBuilder.Type.RoleType.getPlayersReq(this.label);
+        getPlayerTypes(): Stream<ThingType> {
+            const request = RequestBuilder.Type.RoleType.getPlayerTypesReq(this.label);
             return this.stream(request)
-                .flatMap((resPart) => Stream.array(resPart.getRoleTypeGetPlayersResPart().getThingTypesList()))
-                .map((thing) => ThingTypeImpl.of(thing));
+                .flatMap((resPart) => Stream.array(resPart.getRoleTypeGetPlayerTypesResPart().getThingTypesList()))
+                .map((thingType) => ThingTypeImpl.of(thingType));
+        }
+
+        getPlayerTypesExplicit(): Stream<ThingType> {
+            const request = RequestBuilder.Type.RoleType.getPlayerTypesExplicitReq(this.label);
+            return this.stream(request)
+                .flatMap((resPart) => Stream.array(resPart.getRoleTypeGetPlayerTypesExplicitResPart().getThingTypesList()))
+                .map((thingType) => ThingTypeImpl.of(thingType));
+        }
+
+        getRelationInstances(): Stream<Relation> {
+            const request = RequestBuilder.Type.RoleType.getRelationInstancesReq(this.label);
+            return this.stream(request)
+                .flatMap((resPart) => Stream.array(resPart.getRoleTypeGetRelationInstancesResPart().getRelationsList()))
+                .map((rel) => RelationImpl.of(rel));
+        }
+
+        getRelationInstancesExplicit(): Stream<Relation> {
+            const request = RequestBuilder.Type.RoleType.getRelationInstancesExplicitReq(this.label);
+            return this.stream(request)
+                .flatMap((resPart) => Stream.array(resPart.getRoleTypeGetRelationInstancesExplicitResPart().getRelationsList()))
+                .map((rel) => RelationImpl.of(rel));
+        }
+
+        getPlayerInstances(): Stream<Thing> {
+            const request = RequestBuilder.Type.RoleType.getPlayerInstancesReq(this.label);
+            return this.stream(request)
+                .flatMap((resPart) => Stream.array(resPart.getRoleTypeGetPlayerInstancesResPart().getThingsList()))
+                .map((thing) => ThingImpl.of(thing));
+        }
+
+        getPlayerInstancesExplicit(): Stream<Thing> {
+            const request = RequestBuilder.Type.RoleType.getPlayerInstancesExplicitReq(this.label);
+            return this.stream(request)
+                .flatMap((resPart) => Stream.array(resPart.getRoleTypeGetPlayerInstancesExplicitResPart().getThingsList()))
+                .map((thing) => ThingImpl.of(thing));
         }
 
         async isDeleted(): Promise<boolean> {

--- a/concept/type/RoleTypeImpl.ts
+++ b/concept/type/RoleTypeImpl.ts
@@ -58,7 +58,7 @@ export namespace RoleTypeImpl {
 
     export function of(typeProto: TypeProto) {
         if (!typeProto) return null;
-        return new RoleTypeImpl(typeProto.getScope(), typeProto.getLabel(), typeProto.getIsroot(), typeProto.getIsabstract());
+        return new RoleTypeImpl(typeProto.getScope(), typeProto.getLabel(), typeProto.getIsRoot(), typeProto.getIsAbstract());
     }
 
     export class Remote extends TypeImpl.Remote implements RoleType.Remote {

--- a/concept/type/ThingTypeImpl.ts
+++ b/concept/type/ThingTypeImpl.ts
@@ -35,8 +35,8 @@ import BAD_ENCODING = ErrorMessage.Concept.BAD_ENCODING;
 
 export class ThingTypeImpl extends TypeImpl implements ThingType {
 
-    constructor(name: string, root: boolean) {
-        super(Label.of(name), root);
+    constructor(name: string, root: boolean, abstract: boolean) {
+        super(Label.of(name), root, abstract);
     }
 
     protected get className(): string {
@@ -44,7 +44,7 @@ export class ThingTypeImpl extends TypeImpl implements ThingType {
     }
 
     asRemote(transaction: TypeDBTransaction): ThingType.Remote {
-        return new ThingTypeImpl.Remote(transaction as TypeDBTransaction.Extended, this.label, this.root);
+        return new ThingTypeImpl.Remote(transaction as TypeDBTransaction.Extended, this.label, this.root, this.abstract);
     }
 
     isThingType(): boolean {
@@ -68,7 +68,7 @@ export namespace ThingTypeImpl {
             case TypeProto.Encoding.ATTRIBUTE_TYPE:
                 return AttributeTypeImpl.of(thingTypeProto);
             case TypeProto.Encoding.THING_TYPE:
-                return new ThingTypeImpl(thingTypeProto.getLabel(), thingTypeProto.getRoot());
+                return new ThingTypeImpl(thingTypeProto.getLabel(), thingTypeProto.getIsroot(), thingTypeProto.getIsabstract());
             default:
                 throw new TypeDBClientError(BAD_ENCODING.message(thingTypeProto.getEncoding()));
         }
@@ -76,8 +76,8 @@ export namespace ThingTypeImpl {
 
     export class Remote extends TypeImpl.Remote implements ThingType.Remote {
 
-        constructor(transaction: TypeDBTransaction.Extended, label: Label, root: boolean) {
-            super(transaction, label, root);
+        constructor(transaction: TypeDBTransaction.Extended, label: Label, root: boolean, abstract: boolean) {
+            super(transaction, label, root, abstract);
         }
 
         protected get className(): string {
@@ -85,7 +85,7 @@ export namespace ThingTypeImpl {
         }
 
         asRemote(transaction: TypeDBTransaction): ThingType.Remote {
-            return new ThingTypeImpl.Remote(transaction as TypeDBTransaction.Extended, this.label, this.root);
+            return new ThingTypeImpl.Remote(transaction as TypeDBTransaction.Extended, this.label, this.root, this.abstract);
         }
 
         isThingType(): boolean {
@@ -249,6 +249,11 @@ export namespace ThingTypeImpl {
         protected async setSupertype(thingType: ThingType): Promise<void> {
             const request = RequestBuilder.Type.ThingType.setSupertypeReq(this.label, ThingType.proto(thingType));
             await this.execute(request);
+        }
+
+        async getSyntax(): Promise<string> {
+            const request = RequestBuilder.Type.ThingType.getSyntaxReq(this.label);
+            return (await this.execute(request)).getThingTypeGetSyntaxRes().getSyntax();
         }
     }
 }

--- a/concept/type/ThingTypeImpl.ts
+++ b/concept/type/ThingTypeImpl.ts
@@ -68,7 +68,7 @@ export namespace ThingTypeImpl {
             case TypeProto.Encoding.ATTRIBUTE_TYPE:
                 return AttributeTypeImpl.of(thingTypeProto);
             case TypeProto.Encoding.THING_TYPE:
-                return new ThingTypeImpl(thingTypeProto.getLabel(), thingTypeProto.getIsroot(), thingTypeProto.getIsabstract());
+                return new ThingTypeImpl(thingTypeProto.getLabel(), thingTypeProto.getIsRoot(), thingTypeProto.getIsAbstract());
             default:
                 throw new TypeDBClientError(BAD_ENCODING.message(thingTypeProto.getEncoding()));
         }

--- a/concept/type/TypeImpl.ts
+++ b/concept/type/TypeImpl.ts
@@ -36,18 +36,24 @@ export abstract class TypeImpl extends ConceptImpl implements Type {
 
     private readonly _label: Label;
     private readonly _root: boolean;
+    private readonly _abstract: boolean;
 
-    protected constructor(label: Label, root: boolean) {
+    protected constructor(label: Label, root: boolean, abstract: boolean) {
         super();
         if (!label) throw new TypeDBClientError(MISSING_LABEL);
         this._label = label;
         this._root = root;
+        this._abstract = abstract;
     }
 
     abstract asRemote(transaction: TypeDBTransaction): Type.Remote;
 
     get root(): boolean {
         return this._root;
+    }
+
+    get abstract(): boolean {
+        return this._abstract;
     }
 
     get label(): Label {
@@ -87,18 +93,24 @@ export namespace TypeImpl {
 
         private _label: Label;
         private readonly _root: boolean;
+        private readonly _abstract: boolean;
 
-        protected constructor(transaction: TypeDBTransaction.Extended, label: Label, root: boolean) {
+        protected constructor(transaction: TypeDBTransaction.Extended, label: Label, root: boolean, abstract: boolean) {
             super(transaction);
             if (!label) throw new TypeDBClientError(ErrorMessage.Concept.MISSING_LABEL);
             this._label = label;
             this._root = root;
+            this._abstract = abstract;
         }
 
         abstract asRemote(transaction: TypeDBTransaction): Type.Remote;
 
         get root(): boolean {
             return this._root;
+        }
+
+        get abstract(): boolean {
+            return this._abstract;
         }
 
         get label(): Label {
@@ -150,11 +162,6 @@ export namespace TypeImpl {
             const request = RequestBuilder.Type.setLabelReq(this._label, label);
             await this.execute(request);
             this._label = new Label(this.label.scope, label);
-        }
-
-        async isAbstract(): Promise<boolean> {
-            const request = RequestBuilder.Type.isAbstractReq(this._label);
-            return this.execute(request).then((res) => res.getTypeIsAbstractRes().getAbstract());
         }
 
         protected async execute(request: TransactionProto.Req): Promise<TypeProto.Res> {

--- a/dependencies/vaticle/artifacts.bzl
+++ b/dependencies/vaticle/artifacts.bzl
@@ -29,7 +29,7 @@ def vaticle_typedb_artifacts():
         artifact_name = "typedb-server-{platform}-{version}.{ext}",
         tag_source = deployment["artifact.release"],
         commit_source = deployment["artifact.snapshot"],
-        tag = "2.11.1"
+        tag = "2.14.3"
     )
 
 def vaticle_typedb_cluster_artifacts():

--- a/dependencies/vaticle/artifacts.bzl
+++ b/dependencies/vaticle/artifacts.bzl
@@ -39,5 +39,5 @@ def vaticle_typedb_cluster_artifacts():
         artifact_name = "typedb-cluster-all-{platform}-{version}.{ext}",
         tag_source = deployment_private["artifact.release"],
         commit_source = deployment_private["artifact.snapshot"],
-        tag = "2.11.1"
+        tag = "2.13.0"
     )

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -40,5 +40,5 @@ def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
         remote = "https://github.com/vaticle/typedb-behaviour",
-        commit = "6ff247cf6d90b941da015414cb8f79fc97647a98", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        commit = "21ae86ac44e84c7dbb4351a9006b97a555f0a215", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@grpc/grpc-js": "1.5.0",
     "google-protobuf": "3.19.3",
-    "typedb-protocol": "2.14.0",
+    "typedb-protocol": "https://repo.vaticle.com/repository/npm-snapshot/typedb-protocol/-/typedb-protocol-0.0.0-e6f62093b54499b20e5202279bdea117bcce7c39.tgz",
     "uuid": "8.3.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@grpc/grpc-js": "1.5.0",
     "google-protobuf": "3.19.3",
-    "typedb-protocol": "2.10.0",
+    "typedb-protocol": "2.14.0",
     "uuid": "8.3.2"
   },
   "devDependencies": {

--- a/test/behaviour/concept/type/relationtype/RelationTypeSteps.ts
+++ b/test/behaviour/concept/type/relationtype/RelationTypeSteps.ts
@@ -81,7 +81,7 @@ Then("relation\\({type_label}) get overridden role\\({type_label}) get label: {t
 
 When("relation\\({type_label}) get role\\({type_label}) is abstract: {bool}", async (relationLabel: string, roleLabel: string, isAbstract: boolean) => {
     const roleType = await (await tx().concepts.getRelationType(relationLabel)).asRemote(tx()).getRelates(roleLabel);
-    assert.strictEqual(await roleType.asRemote(tx()).isAbstract(), isAbstract);
+    assert.strictEqual(roleType.abstract, isAbstract);
 });
 
 async function getActualRelatedRoles(relationLabel: string) {

--- a/test/behaviour/concept/type/relationtype/RelationTypeSteps.ts
+++ b/test/behaviour/concept/type/relationtype/RelationTypeSteps.ts
@@ -141,7 +141,7 @@ Then("relation\\({type_label}) get role\\({type_label}) get supertypes do not co
 
 async function getActualPlayersForRelatedRole(relationLabel: string, roleLabel: string) {
     const roleType = await (await tx().concepts.getRelationType(relationLabel)).asRemote(tx()).getRelates(roleLabel);
-    return await roleType.asRemote(tx()).getPlayers().map(tt => tt.label.scopedName).collect();
+    return await roleType.asRemote(tx()).getPlayerTypes().map(tt => tt.label.scopedName).collect();
 }
 
 Then("relation\\({type_label}) get role\\({type_label}) get players contain:", async (relationLabel: string, roleLabel: string, playerLabelsTable: DataTable) => {

--- a/test/behaviour/concept/type/thingtype/ThingTypeSteps.ts
+++ b/test/behaviour/concept/type/thingtype/ThingTypeSteps.ts
@@ -114,7 +114,7 @@ When("{root_label}\\({type_label}) set abstract: {bool}; throws exception", asyn
 });
 
 When("{root_label}\\({type_label}) is abstract: {bool}", async (rootLabel: RootLabel, typeLabel: string, isAbstract: boolean) => {
-    await assert.strictEqual(await (await getThingType(rootLabel, typeLabel)).asRemote(tx()).isAbstract(), isAbstract);
+    assert.strictEqual((await getThingType(rootLabel, typeLabel)).abstract, isAbstract);
 });
 
 When("{root_label}\\({type_label}) set supertype: {type_label}", async (rootLabel: RootLabel, typeLabel: string, superLabel: string) => {

--- a/test/common/start-cluster-servers.sh
+++ b/test/common/start-cluster-servers.sh
@@ -44,13 +44,13 @@ rm -rf 1 2 3 typedb-cluster-all
 
 bazel run //test:typedb-cluster-extractor -- typedb-cluster-all
 echo Successfully unarchived TypeDB distribution. Creating 3 copies.
-cp -r typedb-cluster-all/$TYPEDB/ 1 && cp -r typedb-cluster-all/$TYPEDB/ 2 && cp -r typedb-cluster-all/$TYPEDB/ 3
+cp -r typedb-cluster-all 1 && cp -r typedb-cluster-all 2 && cp -r typedb-cluster-all 3
 echo Starting a cluster consisting of 3 servers...
 server_start 1 &
 server_start 2 &
 server_start 3 &
 
-ROOT_CA=`realpath typedb-cluster-all/$TYPEDB/server/conf/encryption/ext-root-ca.pem`
+ROOT_CA=`realpath typedb-cluster-all/server/conf/encryption/ext-root-ca.pem`
 export ROOT_CA
 
 POLL_INTERVAL_SECS=0.5

--- a/test/integration/test-concept.js
+++ b/test/integration/test-concept.js
@@ -185,7 +185,7 @@ async function run() {
         father = await fathership.asRemote(tx).getRelates("father");
         await man.asRemote(tx).setPlays(father, parent);
         const playingRoles = (await man.asRemote(tx).getPlays().collect()).map(role => role.label.scopedName);
-        const roleplayers = (await father.asRemote(tx).getPlayers().collect()).map(player => player.label.scopedName);
+        const roleplayers = (await father.asRemote(tx).getPlayerTypes().collect()).map(player => player.label.scopedName);
         await tx.commit();
         await tx.close();
         assert(playingRoles.includes("fathership:father"));

--- a/test/integration/test-concept.js
+++ b/test/integration/test-concept.js
@@ -152,13 +152,15 @@ async function run() {
 
     try {
         tx = await session.transaction(TransactionType.WRITE);
-        const whale = await tx.concepts.putEntityType("whale");
+        let whale = await tx.concepts.putEntityType("whale");
         await whale.asRemote(tx).setAbstract();
-        const isAbstractAfterSet = await whale.asRemote(tx).isAbstract();
+        whale = await tx.concepts.getEntityType("whale");
+        const isAbstractAfterSet = whale.abstract;
         assert(isAbstractAfterSet);
         console.log(`set abstract - SUCCESS - 'whale' ${isAbstractAfterSet ? "is" : "is not"} abstract.`);
         await whale.asRemote(tx).unsetAbstract();
-        const isAbstractAfterUnset = await whale.asRemote(tx).isAbstract();
+        whale = await tx.concepts.getEntityType("whale");
+        const isAbstractAfterUnset = whale.abstract;
         assert(!isAbstractAfterUnset);
         await tx.rollback();
         await tx.close();

--- a/yarn.lock
+++ b/yarn.lock
@@ -4246,10 +4246,9 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typedb-protocol@2.14.0:
-  version "2.14.0"
-  resolved "https://registry.yarnpkg.com/typedb-protocol/-/typedb-protocol-2.14.0.tgz#5f93685573647441a344b5a1a40fc8add749bcb4"
-  integrity sha512-4n4P2gLt/z1X3E/SxhAb2Jh1ROEDd55plg98yJiiY8uSA/BsEZLxvLQVc+XqG9VRnNFmamEXC18Qv39dnK3MrQ==
+"typedb-protocol@https://repo.vaticle.com/repository/npm-snapshot/typedb-protocol/-/typedb-protocol-0.0.0-e6f62093b54499b20e5202279bdea117bcce7c39.tgz":
+  version "0.0.0-e6f62093b54499b20e5202279bdea117bcce7c39"
+  resolved "https://repo.vaticle.com/repository/npm-snapshot/typedb-protocol/-/typedb-protocol-0.0.0-e6f62093b54499b20e5202279bdea117bcce7c39.tgz#cb287256ba67992e0a4385b0652d0c3e37dffb10"
   dependencies:
     "@grpc/grpc-js" "1.5.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4246,10 +4246,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typedb-protocol@2.10.0:
-  version "2.10.0"
-  resolved "https://registry.yarnpkg.com/typedb-protocol/-/typedb-protocol-2.10.0.tgz#92f97f026a10d36b44cdb58792b912d822bf30b5"
-  integrity sha512-4SazuH0ewzGMygOQTVb809SR6k75/iWl6e5njuyKUdvq4lrThs+CPQdAZTHiqIcDDfufk2FMU5n62JEdgbx8Ig==
+typedb-protocol@2.14.0:
+  version "2.14.0"
+  resolved "https://registry.yarnpkg.com/typedb-protocol/-/typedb-protocol-2.14.0.tgz#5f93685573647441a344b5a1a40fc8add749bcb4"
+  integrity sha512-4n4P2gLt/z1X3E/SxhAb2Jh1ROEDd55plg98yJiiY8uSA/BsEZLxvLQVc+XqG9VRnNFmamEXC18Qv39dnK3MrQ==
   dependencies:
     "@grpc/grpc-js" "1.5.0"
 


### PR DESCRIPTION
## What is the goal of this PR?

We updated to the latest TypeDB protocol (2.14.x), added new `RoleType` methods and `ThingType.getSyntax`.

## What are the changes implemented in this PR?

- Update to latest protocol
- Add new `RoleType` methods and `ThingType.getSyntax`
- Bump Core and Cluster artifacts, and bump `typedb-behaviour`
- Fix (long-standing?) error in test script that starts Cluster