### PR TITLE
Cluster password policy and user management support

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -214,8 +214,10 @@ checkstyle_test(
     ]),
     license_type = "apache-header",
 )
+
 checkstyle_test(
     name = "checkstyle-license",
+    size = "small",
     include = ["LICENSE"],
     license_type = "apache-fulltext",
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -41,8 +41,9 @@ java_deps()
 # Load //builder/kotlin
 load("@vaticle_dependencies//builder/kotlin:deps.bzl", kotlin_deps = "deps")
 kotlin_deps()
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kotlin_repositories", "kt_register_toolchains")
+load("@io_bazel_rules_kotlin//kotlin:repositories.bzl", "kotlin_repositories")
 kotlin_repositories()
+load("@io_bazel_rules_kotlin//kotlin:core.bzl", "kt_register_toolchains")
 kt_register_toolchains()
 
 # Load //builder/python

--- a/api/connection/user/User.ts
+++ b/api/connection/user/User.ts
@@ -23,7 +23,7 @@ export interface User {
 
     readonly username: string;
 
-    password(password: string): Promise<void>;
+    passwordExpiryDays(): Promise<number>;
 
-    delete(): Promise<void>;
+    passwordUpdate(oldPassword: string, newPassword: string): Promise<void>;
 }

--- a/api/connection/user/User.ts
+++ b/api/connection/user/User.ts
@@ -23,7 +23,7 @@ export interface User {
 
     readonly username: string;
 
-    passwordExpiryDays(): Promise<number>;
+    readonly passwordExpiryDays: number;
 
     passwordUpdate(oldPassword: string, newPassword: string): Promise<void>;
 }

--- a/api/connection/user/UserManager.ts
+++ b/api/connection/user/UserManager.ts
@@ -23,11 +23,15 @@ import { User } from "./User";
 
 export interface UserManager {
 
-    get(name: string): Promise<User>;
-
     contains(name: string): Promise<boolean>;
 
     create(name: string, password: string): Promise<void>;
 
+    delete(name: string): Promise<void>;
+
+    get(name: string): Promise<User>;
+
     all(): Promise<User[]>;
+
+    passwordSet(name: string, password: string): Promise<void>;
 }

--- a/common/rpc/RequestBuilder.ts
+++ b/common/rpc/RequestBuilder.ts
@@ -102,8 +102,8 @@ export namespace RequestBuilder {
         }
 
         export namespace User {
-            export function passwordUpdateReq(name: string, password_old: string, password_new: string): ClusterUserProto.PasswordUpdate.Req {
-                return new ClusterUserProto.PasswordUpdate.Req().setUsername(name).setPasswordOld(password_old).setPasswordNew(password_new);
+            export function passwordUpdateReq(name: string, passwordOld: string, passwordNew: string): ClusterUserProto.PasswordUpdate.Req {
+                return new ClusterUserProto.PasswordUpdate.Req().setUsername(name).setPasswordOld(passwordOld).setPasswordNew(passwordNew);
             }
 
             export function tokenReq(username: string) {

--- a/common/rpc/RequestBuilder.ts
+++ b/common/rpc/RequestBuilder.ts
@@ -84,28 +84,34 @@ export namespace RequestBuilder {
                 return new ClusterUserManagerProto.Create.Req().setUsername(name).setPassword(password);
             }
 
+            export function deleteReq(name: string): ClusterUserManagerProto.Delete.Req {
+                return new ClusterUserManagerProto.Delete.Req().setUsername(name);
+            }
+
             export function allReq(): ClusterUserManagerProto.All.Req {
                 return new ClusterUserManagerProto.All.Req();
+            }
+
+            export function passwordSetReq(name: string, password: string): ClusterUserManagerProto.PasswordSet.Req {
+                return new ClusterUserManagerProto.PasswordSet.Req().setUsername(name).setPassword(password);
+            }
+            
+            export function getReq(name: string): ClusterUserManagerProto.Get.Req {
+                return new ClusterUserManagerProto.Get.Req().setUsername(name);
             }
         }
 
         export namespace User {
-            export function passwordReq(name: string, password: string): ClusterUserProto.Password.Req {
-                return new ClusterUserProto.Password.Req().setUsername(name).setPassword(password);
+            export function passwordUpdateReq(name: string, password_old: string, password_new: string): ClusterUserProto.PasswordUpdate.Req {
+                return new ClusterUserProto.PasswordUpdate.Req().setUsername(name).setPasswordOld(password_old).setPasswordNew(password_new);
             }
 
             export function tokenReq(username: string) {
                 return new ClusterUserProto.Token.Req().setUsername(username);
             }
-
-            export function deleteReq(name: string): ClusterUserProto.Delete.Req {
-                return new ClusterUserProto.Delete.Req().setUsername(name);
-            }
-
         }
 
         export namespace DatabaseManager {
-
             export function getReq(name: string) {
                 return new ClusterDatabaseManager.Get.Req().setName(name);
             }

--- a/connection/cluster/ClusterServerStub.ts
+++ b/connection/cluster/ClusterServerStub.ts
@@ -146,10 +146,21 @@ export class ClusterServerStub extends TypeDBStub {
         );
     }
 
-    userPassword(req: ClusterUser.Password.Req): Promise<void> {
+    userDelete(req: ClusterUserManager.Delete.Req): Promise<void> {
         return this.mayRenewToken(() =>
             new Promise<void>((resolve, reject) => {
-                this._clusterStub.user_password(req, (err, res) => {
+                this._clusterStub.users_delete(req, (err, res) => {
+                    if (err) reject(new TypeDBClientError(err));
+                    else resolve();
+                });
+            })
+        );
+    }
+
+    userPasswordSet(req: ClusterUserManager.PasswordSet.Req): Promise<void> {
+        return this.mayRenewToken(() =>
+            new Promise<void>((resolve, reject) => {
+                this._clusterStub.users_password_set(req, (err, res) => {
                     if (err) reject(new TypeDBClientError(err));
                     else resolve();
                 })
@@ -157,10 +168,21 @@ export class ClusterServerStub extends TypeDBStub {
         );
     }
 
-    userDelete(req: ClusterUser.Delete.Req): Promise<void> {
+    userGet(req: ClusterUserManager.Get.Req): Promise<ClusterUserManager.Get.Res> {
+        return this.mayRenewToken(() =>
+            new Promise<ClusterUserManager.Get.Res>((resolve, reject) => {
+                this._clusterStub.users_get(req, (err, res) => {
+                    if (err) reject(new TypeDBClientError(err));
+                    else resolve(res);
+                });
+            })
+        );
+    }
+
+    userPasswordUpdate(req: ClusterUser.PasswordUpdate.Req): Promise<void> {
         return this.mayRenewToken(() =>
             new Promise<void>((resolve, reject) => {
-                this._clusterStub.user_delete(req, (err, res) => {
+                this._clusterStub.user_password_update(req, (err, res) => {
                     if (err) reject(new TypeDBClientError(err));
                     else resolve();
                 })

--- a/connection/cluster/ClusterServerStub.ts
+++ b/connection/cluster/ClusterServerStub.ts
@@ -135,7 +135,7 @@ export class ClusterServerStub extends TypeDBStub {
         );
     }
 
-    userCreate(req: ClusterUserManager.Create.Req): Promise<void> {
+    usersCreate(req: ClusterUserManager.Create.Req): Promise<void> {
         return this.mayRenewToken(() =>
             new Promise<void>((resolve, reject) => {
                 this._clusterStub.users_create(req, (err, res) => {
@@ -146,7 +146,7 @@ export class ClusterServerStub extends TypeDBStub {
         );
     }
 
-    userDelete(req: ClusterUserManager.Delete.Req): Promise<void> {
+    usersDelete(req: ClusterUserManager.Delete.Req): Promise<void> {
         return this.mayRenewToken(() =>
             new Promise<void>((resolve, reject) => {
                 this._clusterStub.users_delete(req, (err, res) => {
@@ -157,7 +157,7 @@ export class ClusterServerStub extends TypeDBStub {
         );
     }
 
-    userPasswordSet(req: ClusterUserManager.PasswordSet.Req): Promise<void> {
+    usersPasswordSet(req: ClusterUserManager.PasswordSet.Req): Promise<void> {
         return this.mayRenewToken(() =>
             new Promise<void>((resolve, reject) => {
                 this._clusterStub.users_password_set(req, (err, res) => {
@@ -168,7 +168,7 @@ export class ClusterServerStub extends TypeDBStub {
         );
     }
 
-    userGet(req: ClusterUserManager.Get.Req): Promise<ClusterUserManager.Get.Res> {
+    usersGet(req: ClusterUserManager.Get.Req): Promise<ClusterUserManager.Get.Res> {
         return this.mayRenewToken(() =>
             new Promise<ClusterUserManager.Get.Res>((resolve, reject) => {
                 this._clusterStub.users_get(req, (err, res) => {

--- a/connection/cluster/ClusterUser.ts
+++ b/connection/cluster/ClusterUser.ts
@@ -19,6 +19,7 @@
  * under the License.
  */
 
+import { ClusterUser as ClusterUserProto } from "typedb-protocol/cluster/cluster_user_pb";
 import { Database } from "../../api/connection/database/Database";
 import { User } from "../../api/connection/user/User";
 import { RequestBuilder } from "../../common/rpc/RequestBuilder";
@@ -29,10 +30,19 @@ export class ClusterUser implements User {
 
     private readonly _client: ClusterClient;
     private readonly _username: string;
+    private readonly _passwordExpiryDays: number;
 
-    constructor(client: ClusterClient, username: string) {
+    constructor(client: ClusterClient, username: string, passwordExpiryDays: number) {
         this._client = client;
         this._username = username;
+        this._passwordExpiryDays = passwordExpiryDays;
+    }
+
+    static of(user: ClusterUserProto, client: ClusterClient): ClusterUser {
+        switch (user.getPasswordExpiryCase()) {
+            case ClusterUserProto.PasswordExpiryCase.PASSWORDEXPIRY_NOT_SET: return new ClusterUser(client, user.getUsername(), null);
+            case ClusterUserProto.PasswordExpiryCase.PASSWORD_EXPIRY_DAYS: return new ClusterUser(client, user.getUsername(), user.getPasswordExpiryDays());
+        }
     }
 
     async password(password: string): Promise<void> {

--- a/connection/cluster/ClusterUserManager.ts
+++ b/connection/cluster/ClusterUserManager.ts
@@ -54,28 +54,28 @@ export class ClusterUserManager implements UserManager {
 
     create(username: string, password: string): Promise<void> {
         const failsafeTask = new UserManagerFailsafeTask(this._client, (replica: Database.Replica) => {
-            return this._client.stub(replica.address).userCreate(RequestBuilder.Cluster.UserManager.createReq(username, password))
+            return this._client.stub(replica.address).usersCreate(RequestBuilder.Cluster.UserManager.createReq(username, password))
         })
         return failsafeTask.runPrimaryReplica();
     }
 
     delete(username: string): Promise<void> {
         const failsafeTask = new UserManagerFailsafeTask(this._client, (replica: Database.Replica) => {
-            return this._client.stub(replica.address).userDelete(RequestBuilder.Cluster.UserManager.deleteReq(username))
+            return this._client.stub(replica.address).usersDelete(RequestBuilder.Cluster.UserManager.deleteReq(username))
         })
         return failsafeTask.runPrimaryReplica();
     }
 
     async get(username: string): Promise<ClusterUser> {
         const failsafeTask = new UserManagerFailsafeTask(this._client, (replica: Database.Replica) => {
-            return this._client.stub(replica.address).userGet(RequestBuilder.Cluster.UserManager.getReq(username))
+            return this._client.stub(replica.address).usersGet(RequestBuilder.Cluster.UserManager.getReq(username))
         })
         return ClusterUser.of((await failsafeTask.runPrimaryReplica()).getUser(), this._client);
     }
 
     passwordSet(username: string, password: string): Promise<void> {
         const failsafeTask = new UserManagerFailsafeTask(this._client, (replica: Database.Replica) => {
-            return this._client.stub(replica.address).userPasswordSet(RequestBuilder.Cluster.UserManager.passwordSetReq(username, password))
+            return this._client.stub(replica.address).usersPasswordSet(RequestBuilder.Cluster.UserManager.passwordSetReq(username, password))
         })
         return failsafeTask.runPrimaryReplica();
     }

--- a/connection/cluster/ClusterUserManager.ts
+++ b/connection/cluster/ClusterUserManager.ts
@@ -35,35 +35,35 @@ export class ClusterUserManager implements UserManager {
         this._client = client;
     }
 
-    all(): Promise<User[]> {
+    async all(): Promise<User[]> {
         const failsafeTask = new UserManagerFailsafeTask(this._client, (replica: Database.Replica) => {
             return this._client.stub(replica.address).usersAll(RequestBuilder.Cluster.UserManager.allReq())
                 .then((res) => {
                     return res.getUsersList().map(user => ClusterUser.of(user, this._client));
                 });
         });
-        return failsafeTask.runPrimaryReplica();
+        return await failsafeTask.runPrimaryReplica();
     }
 
-    contains(username: string): Promise<boolean> {
+    async contains(username: string): Promise<boolean> {
         const failsafeTask = new UserManagerFailsafeTask(this._client, (replica: Database.Replica) => {
             return this._client.stub(replica.address).usersContains(RequestBuilder.Cluster.UserManager.containsReq(username))
         })
-        return failsafeTask.runPrimaryReplica();
+        return await failsafeTask.runPrimaryReplica();
     }
 
-    create(username: string, password: string): Promise<void> {
+    async create(username: string, password: string): Promise<void> {
         const failsafeTask = new UserManagerFailsafeTask(this._client, (replica: Database.Replica) => {
             return this._client.stub(replica.address).usersCreate(RequestBuilder.Cluster.UserManager.createReq(username, password))
         })
-        return failsafeTask.runPrimaryReplica();
+        await failsafeTask.runPrimaryReplica();
     }
 
-    delete(username: string): Promise<void> {
+    async delete(username: string): Promise<void> {
         const failsafeTask = new UserManagerFailsafeTask(this._client, (replica: Database.Replica) => {
             return this._client.stub(replica.address).usersDelete(RequestBuilder.Cluster.UserManager.deleteReq(username))
         })
-        return failsafeTask.runPrimaryReplica();
+        await failsafeTask.runPrimaryReplica();
     }
 
     async get(username: string): Promise<ClusterUser> {
@@ -73,11 +73,11 @@ export class ClusterUserManager implements UserManager {
         return ClusterUser.of((await failsafeTask.runPrimaryReplica()).getUser(), this._client);
     }
 
-    passwordSet(username: string, password: string): Promise<void> {
+    async passwordSet(username: string, password: string): Promise<void> {
         const failsafeTask = new UserManagerFailsafeTask(this._client, (replica: Database.Replica) => {
             return this._client.stub(replica.address).usersPasswordSet(RequestBuilder.Cluster.UserManager.passwordSetReq(username, password))
         })
-        return failsafeTask.runPrimaryReplica();
+        await failsafeTask.runPrimaryReplica();
     }
 }
 
@@ -90,7 +90,7 @@ class UserManagerFailsafeTask<T> extends FailsafeTask<T> {
         this._task = task;
     }
 
-    run(replica: Database.Replica): Promise<T> {
-        return this._task(replica);
+    async run(replica: Database.Replica): Promise<T> {
+        return await this._task(replica);
     }
 }

--- a/dependencies/vaticle/artifacts.bzl
+++ b/dependencies/vaticle/artifacts.bzl
@@ -29,7 +29,7 @@ def vaticle_typedb_artifacts():
         artifact_name = "typedb-server-{platform}-{version}.{ext}",
         tag_source = deployment["artifact.release"],
         commit_source = deployment["artifact.snapshot"],
-        tag = "2.14.3"
+        commit = "886896328b598a2e89e0ac149ac50a6af43dd49b",
     )
 
 def vaticle_typedb_cluster_artifacts():
@@ -39,5 +39,5 @@ def vaticle_typedb_cluster_artifacts():
         artifact_name = "typedb-cluster-all-{platform}-{version}.{ext}",
         tag_source = deployment_private["artifact.release"],
         commit_source = deployment_private["artifact.snapshot"],
-        tag = "2.13.0"
+        commit = "ff021f6201db41c1f81af1dfec5c90b8b9803efe",
     )

--- a/dependencies/vaticle/artifacts.bzl
+++ b/dependencies/vaticle/artifacts.bzl
@@ -29,7 +29,7 @@ def vaticle_typedb_artifacts():
         artifact_name = "typedb-server-{platform}-{version}.{ext}",
         tag_source = deployment["artifact.release"],
         commit_source = deployment["artifact.snapshot"],
-        commit = "886896328b598a2e89e0ac149ac50a6af43dd49b",
+        tag = "2.16.1",
     )
 
 def vaticle_typedb_cluster_artifacts():
@@ -39,5 +39,5 @@ def vaticle_typedb_cluster_artifacts():
         artifact_name = "typedb-cluster-all-{platform}-{version}.{ext}",
         tag_source = deployment_private["artifact.release"],
         commit_source = deployment_private["artifact.snapshot"],
-        commit = "ff021f6201db41c1f81af1dfec5c90b8b9803efe",
+        tag = "2.16.1",
     )

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -25,7 +25,7 @@ def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
         remote = "https://github.com/vaticle/dependencies",
-        commit = "4464b506ca469f37d3b696fb2f1eda34061cdaa1", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        commit = "05c14b4060c4abfcd42608ee9309b755f0464c0c", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 #TODO: MOVE NATIVE_TYPEDB_ARTIFACT INTO DEPENDENCIES, THEN REMOVE THIS DEPENDENCY
@@ -33,12 +33,12 @@ def vaticle_typedb_common():
     git_repository(
         name = "vaticle_typedb_common",
         remote = "https://github.com/vaticle/typedb-common",
-        commit = "d36b2595904ab069fca56b9ceb17d005f0b39110" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
+        commit = "775a5b22a34baa47b6ad7cf8dd6bc12a21684efb" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
     )
 
 def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
         remote = "https://github.com/vaticle/typedb-behaviour",
-        commit = "21ae86ac44e84c7dbb4351a9006b97a555f0a215", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        commit = "04ec1f75cc376524b3cac75af37e1716230845e0", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@grpc/grpc-js": "1.5.0",
     "google-protobuf": "3.19.3",
-    "typedb-protocol": "https://repo.vaticle.com/repository/npm-snapshot/typedb-protocol/-/typedb-protocol-0.0.0-bc50a114dc4de47cc02208970f319c9a97b6fda7.tgz",
+    "typedb-protocol": "2.16.1",
     "uuid": "8.3.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@grpc/grpc-js": "1.5.0",
     "google-protobuf": "3.19.3",
-    "typedb-protocol": "2.14.1",
+    "typedb-protocol": "https://repo.vaticle.com/repository/npm-snapshot/typedb-protocol/-/typedb-protocol-0.0.0-bc50a114dc4de47cc02208970f319c9a97b6fda7.tgz",
     "uuid": "8.3.2"
   },
   "devDependencies": {

--- a/test/behaviour/connection/user/UserSteps.ts
+++ b/test/behaviour/connection/user/UserSteps.ts
@@ -38,20 +38,23 @@ Then("users create: {word}, {word}", async (username: string, password: string) 
     await getClient().users.create(username, password);
 });
 
-Then("user password: {word}, {word}", async (username: string, password: string) => {
+Then("users delete: {word}", async (username: string) => {
+    await getClient().users.delete(username);
+});
+
+Then("users password set: {word}, {word}", async (username: string, password: string) => {
+    await getClient().users.passwordSet(username, password);
+});
+
+Then("user password update: {word}, {word}, {word}", async (username: string, passwordOld: string, passwordNew: string) => {
     const user = await getClient().users.get(username);
-    await user.password(password);
+    await user.passwordUpdate(passwordOld, passwordNew);
 });
 
 Then("user connect: {word}, {word}", async (username: string, password: string) => {
     const client = await TypeDB.clusterClient([TypeDB.DEFAULT_ADDRESS], new TypeDBCredential(username, password, process.env.ROOT_CA));
     await client.databases.all()
 })
-
-Then("user delete: {word}", async (username: string) => {
-    const user = await getClient().users.get(username);
-    await user.delete();
-});
 
 function getClient(): TypeDBClient.Cluster {
     assert(client.isCluster());

--- a/test/behaviour/cucumber_test.sh
+++ b/test/behaviour/cucumber_test.sh
@@ -83,7 +83,7 @@ if [[ $STARTED -eq 0 ]]; then
   exit 1
 fi
 echo TypeDB $PRODUCT database server started
-node ./node_modules/.bin/cucumber-js ./external/vaticle_typedb_behaviour/**/*.feature --require './**/*.js' --tags 'not @ignore and not @ignore-client-nodejs' --format @cucumber/pretty-formatter && export RESULT=0 || export RESULT=1
+node ./node_modules/.bin/cucumber-js ./external/vaticle_typedb_behaviour/**/*.feature --require './**/*.js' --tags 'not @ignore and not @ignore-typedb-client-nodejs' --format @cucumber/pretty-formatter && export RESULT=0 || export RESULT=1
 echo Tests concluded with exit value $RESULT
 echo Stopping server.
 kill $(lsof -i :1729 | awk '/java/ {print $2}')

--- a/test/integration/test-cluster-failover.js
+++ b/test/integration/test-cluster-failover.js
@@ -45,7 +45,7 @@ function getServerPID(port) {
 }
 
 function serverStart(idx) {
-    spawn(`./${idx}/typedb`, ["cluster",
+    let node = spawn(`./${idx}/typedb`, ["cluster",
         "--storage.data", "server/data",
         "--server.address", `127.0.0.1:${idx}1729`,
         "--server.internal-address.zeromq", `127.0.0.1:${idx}1730`,
@@ -61,6 +61,15 @@ function serverStart(idx) {
         "--server.peers.peer-3.internal-address.grpc", "127.0.0.1:31731",
         "--server.encryption.enable", "true"
     ]);
+    node.stdout.on('data', (data) => {
+        console.log(`stdout: ${data}`);
+    });
+    node.stderr.on('data', (data) => {
+        console.error(`stderr: ${data}`);
+    });
+    node.on('close', (code) => {
+        console.log(`child process exited with code ${code}`);
+    });
 }
 
 async function run() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4246,9 +4246,9 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-"typedb-protocol@https://repo.vaticle.com/repository/npm-snapshot/typedb-protocol/-/typedb-protocol-0.0.0-e6f62093b54499b20e5202279bdea117bcce7c39.tgz":
-  version "0.0.0-e6f62093b54499b20e5202279bdea117bcce7c39"
-  resolved "https://repo.vaticle.com/repository/npm-snapshot/typedb-protocol/-/typedb-protocol-0.0.0-e6f62093b54499b20e5202279bdea117bcce7c39.tgz#cb287256ba67992e0a4385b0652d0c3e37dffb10"
+"typedb-protocol@https://repo.vaticle.com/repository/npm-snapshot/typedb-protocol/-/typedb-protocol-0.0.0-bc50a114dc4de47cc02208970f319c9a97b6fda7.tgz":
+  version "0.0.0-bc50a114dc4de47cc02208970f319c9a97b6fda7"
+  resolved "https://repo.vaticle.com/repository/npm-snapshot/typedb-protocol/-/typedb-protocol-0.0.0-bc50a114dc4de47cc02208970f319c9a97b6fda7.tgz#ff29187e39c147f5a9d216d86addeb1c9c6e2383"
   dependencies:
     "@grpc/grpc-js" "1.5.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4246,9 +4246,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-"typedb-protocol@https://repo.vaticle.com/repository/npm-snapshot/typedb-protocol/-/typedb-protocol-0.0.0-bc50a114dc4de47cc02208970f319c9a97b6fda7.tgz":
-  version "0.0.0-bc50a114dc4de47cc02208970f319c9a97b6fda7"
-  resolved "https://repo.vaticle.com/repository/npm-snapshot/typedb-protocol/-/typedb-protocol-0.0.0-bc50a114dc4de47cc02208970f319c9a97b6fda7.tgz#ff29187e39c147f5a9d216d86addeb1c9c6e2383"
+typedb-protocol@2.16.1:
+  version "2.16.1"
+  resolved "https://registry.yarnpkg.com/typedb-protocol/-/typedb-protocol-2.16.1.tgz#175d07d6668858d4460d7bda60f89fa564c3e4eb"
+  integrity sha512-q+5h+DUCzLGAd4mjsPSFeUo1uDWA7qPTlx7j9tZH3Hs1CR0poGZfJejhzn3id4CUC4BKlcdxg5ItDgcjZJqGtQ==
   dependencies:
     "@grpc/grpc-js" "1.5.0"
 


### PR DESCRIPTION
## What is the goal of this PR?

Add functionality relevant to the changes made in https://github.com/vaticle/typedb-cluster/pull/456:
* Optional password expiry in days for each user.
* The ability for admins to set passwords of other users
* User password update, which requires old and new password

## What are the changes implemented in this PR?

We've added the functionality that is being added in a recent TypeDB Cluster pull request:
* Support updating password now requiring both the old and the new password.
* Add support for retrieving the user password expiry in days. This is optional, depending on whether password expiration is enabled on the server.
* Allow updating password as the admin requiring only a new password.

