### PR TITLE
JSON serialization fixes

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -67,7 +67,7 @@ filegroup(
 
 behaviour_steps_common = [
     "//test/behaviour/connection:ConnectionStepsBase.ts",
-    "//test/behaviour/concept/serialization:SerializationSteps.ts",
+    "//test/behaviour/concept/serialization/json:JSONSteps.ts",
     "//test/behaviour/concept/thing:ThingSteps.ts",
     "//test/behaviour/concept/thing/attribute:AttributeSteps.ts",
     "//test/behaviour/concept/thing/entity:EntitySteps.ts",

--- a/api/answer/ConceptMap.ts
+++ b/api/answer/ConceptMap.ts
@@ -31,7 +31,7 @@ export interface ConceptMap {
 
     readonly explainables: ConceptMap.Explainables;
 
-    JSON(): Record<string, Record<string, boolean | string | number>>;
+    toJSONRecord(): Record<string, Record<string, boolean | string | number>>;
 }
 
 export namespace ConceptMap {

--- a/api/concept/Concept.ts
+++ b/api/concept/Concept.ts
@@ -80,7 +80,7 @@ export interface Concept {
 
     equals(concept: Concept): boolean;
 
-    JSON(): Record<string, boolean | string | number>;
+    toJSONRecord(): Record<string, boolean | string | number>;
 }
 
 export namespace Concept {

--- a/concept/ConceptImpl.ts
+++ b/concept/ConceptImpl.ts
@@ -127,7 +127,7 @@ export abstract class ConceptImpl implements Concept {
 
     abstract equals(concept: Concept): boolean;
 
-    abstract JSON(): Record<string, boolean | string | number>;
+    abstract toJSONRecord(): Record<string, boolean | string | number>;
 }
 
 export namespace ConceptImpl {

--- a/concept/answer/ConceptMapImpl.ts
+++ b/concept/answer/ConceptMapImpl.ts
@@ -53,10 +53,10 @@ export class ConceptMapImpl implements ConceptMap {
         return this._explainables;
     }
 
-    JSON(): Record<string, Record<string, boolean | string | number>> {
+    toJSONRecord(): Record<string, Record<string, boolean | string | number>> {
         const object: Record<string, Record<string, boolean | string | number>> = {}
         for (const key of this._concepts.keys()) {
-            object[key] = this._concepts.get(key).JSON();
+            object[key] = this._concepts.get(key).toJSONRecord();
         }
         return object;
     }

--- a/concept/thing/AttributeImpl.ts
+++ b/concept/thing/AttributeImpl.ts
@@ -79,7 +79,7 @@ export abstract class AttributeImpl extends ThingImpl implements Attribute {
         return this;
     }
 
-    JSON(): Record<string, boolean | string | number> {
+    toJSONRecord(): Record<string, boolean | string | number> {
         let value;
         if (this.value instanceof Date) value = this.value.toISOString().slice(0, -1);
         else value = this.value;
@@ -191,7 +191,7 @@ export namespace AttributeImpl {
             return this;
         }
 
-        JSON(): Record<string, boolean | string | number> {
+        toJSONRecord(): Record<string, boolean | string | number> {
             let value;
             if (this.value instanceof Date) value = this.value.toISOString().slice(0, -1);
             else value = this.value;

--- a/concept/thing/ThingImpl.ts
+++ b/concept/thing/ThingImpl.ts
@@ -77,7 +77,7 @@ export abstract class ThingImpl extends ConceptImpl implements Thing {
         return this;
     }
 
-    JSON(): Record<string, boolean | string | number> {
+    toJSONRecord(): Record<string, boolean | string | number> {
         return {type: this.type.label.name};
     }
 }
@@ -125,7 +125,7 @@ export namespace ThingImpl {
             return this;
         }
 
-        JSON(): Record<string, boolean | string | number> {
+        toJSONRecord(): Record<string, boolean | string | number> {
             return {type: this.type.label.name};
         }
 

--- a/concept/type/TypeImpl.ts
+++ b/concept/type/TypeImpl.ts
@@ -68,7 +68,7 @@ export abstract class TypeImpl extends ConceptImpl implements Type {
         return this;
     }
 
-    JSON(): Record<string, string> {
+    toJSONRecord(): Record<string, string> {
         return {label: this.label.scopedName};
     }
 
@@ -129,7 +129,7 @@ export namespace TypeImpl {
             return this;
         }
 
-        JSON(): Record<string, string> {
+        toJSONRecord(): Record<string, string> {
             return {label: this.label.scopedName};
         }
 

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -39,6 +39,6 @@ def vaticle_typedb_common():
 def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
-        remote = "https://github.com/dmitrii-ubskii/typedb-behaviour",
-        commit = "ab05f18809252674c9b75364a9815c1b264a8b5c" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        remote = "https://github.com/vaticle/typedb-behaviour",
+        commit = "ff4f58b4db2200b907c60b28a2b8ee661449e9c0" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -39,6 +39,6 @@ def vaticle_typedb_common():
 def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
-        remote = "https://github.com/vaticle/typedb-behaviour",
-        commit = "46619244d5f1773505eeacf6d5bd0ae71781f8e8" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        remote = "https://github.com/dmitrii-ubskii/typedb-behaviour",
+        commit = "ab05f18809252674c9b75364a9815c1b264a8b5c" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )

--- a/test/behaviour/concept/serialization/json/BUILD
+++ b/test/behaviour/concept/serialization/json/BUILD
@@ -22,8 +22,22 @@
 load("@vaticle_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
 load("//test/behaviour:rules.bzl", "typedb_behaviour_node_test")
 
+exports_files(["JSONSteps.ts"])
+
 checkstyle_test(
     name = "checkstyle",
     include = glob(["*"]),
     license_type = "apache-header",
+)
+
+typedb_behaviour_node_test(
+    name = "test",
+    features = ["@vaticle_typedb_behaviour//concept/serialization:json.feature"],
+    node_modules = "//:node_modules",
+    package_json = "//:package.json",
+    native_typedb_artifact_core = "//test:native-typedb-artifact",
+    native_typedb_artifact_cluster = "//test:native-typedb-cluster-artifact",
+    client = "//:client-nodejs-targz",
+    steps_core = "//test/behaviour:steps-core-targz",
+    steps_cluster = "//test/behaviour:steps-cluster-targz",
 )

--- a/test/behaviour/concept/serialization/json/JSONSteps.ts
+++ b/test/behaviour/concept/serialization/json/JSONSteps.ts
@@ -20,13 +20,13 @@
  */
 
 import {Then} from "@cucumber/cucumber";
-import {answers} from "../../typeql/TypeQLSteps"
+import {answers} from "../../../typeql/TypeQLSteps"
 import assert = require("assert");
 import {isDeepStrictEqual} from "util";
 
 Then("JSON of answer concepts matches", async (expectedJSON: string) => {
     const expected = JSON.parse(expectedJSON);
-    const actual = answers.map((conceptMap) => conceptMap.JSON());
+    const actual = answers.map((conceptMap) => conceptMap.toJSONRecord());
     assertUnorderedDeepStrictEqual(actual, expected);
 });
 

--- a/test/behaviour/concept/serialization/json/JSONSteps.ts
+++ b/test/behaviour/concept/serialization/json/JSONSteps.ts
@@ -24,7 +24,7 @@ import {answers} from "../../../typeql/TypeQLSteps"
 import assert = require("assert");
 import {isDeepStrictEqual} from "util";
 
-Then("JSON of answer concepts matches", async (expectedJSON: string) => {
+Then("JSON serialization of answers matches", async (expectedJSON: string) => {
     const expected = JSON.parse(expectedJSON);
     const actual = answers.map((conceptMap) => conceptMap.toJSONRecord());
     assertUnorderedDeepStrictEqual(actual, expected);


### PR DESCRIPTION
## What is the goal of this PR?

We update serialization API from `JSON()` to more canonical `toJSONRecord()`* and update the BDD test steps to reflect the changes in typedb-behaviour (https://github.com/vaticle/typedb-behaviour/pull/240).

\* We're avoiding `toJSON()` as it is reserved by JavaScript for built-in JSON serialization. Since our JSON representation is lossy, we'd like the user to be explicit in their intent.