### PR TITLE
Define password expiry in terms of seconds

### DIFF
--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -76,7 +76,7 @@ build:
         export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        .factory/test-core.sh //test/behaviour/connection/... --test_output=errors --jobs=1
+        .factory/test-core.sh $(bazel query //test/behaviour/connection/... except //test/behaviour/connection/user/...) --test_output=errors --jobs=1
     test-behaviour-connection-cluster:
       image: vaticle-ubuntu-22.04
       command: |

--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -76,14 +76,19 @@ build:
         export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        .factory/test-core.sh $(bazel query //test/behaviour/connection/... except //test/behaviour/connection/user/...) --test_output=errors --jobs=1
+        .factory/test-core.sh //test/behaviour/connection/database/... --test_output=errors --jobs=1
+        .factory/test-core.sh //test/behaviour/connection/session/... --test_output=errors --jobs=1
+        .factory/test-core.sh //test/behaviour/connection/transaction/... --test_output=errors --jobs=1
     test-behaviour-connection-cluster:
       image: vaticle-ubuntu-22.04
       command: |
         export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        .factory/test-cluster.sh //test/behaviour/connection/... --test_output=errors --jobs=1
+        .factory/test-cluster.sh //test/behaviour/connection/database/... --test_output=errors --jobs=1
+        .factory/test-cluster.sh //test/behaviour/connection/session/... --test_output=errors --jobs=1
+        .factory/test-cluster.sh //test/behaviour/connection/transaction/... --test_output=errors --jobs=1
+        .factory/test-cluster.sh //test/behaviour/connection/user/... --test_output=errors --jobs=1
     test-behaviour-concept-core:
       image: vaticle-ubuntu-22.04
       command: |

--- a/BUILD
+++ b/BUILD
@@ -96,7 +96,7 @@ filegroup(
     srcs = behaviour_steps_common + [
         "//test/behaviour/connection/user:UserSteps.ts",
         "//test/behaviour/connection:ConnectionStepsCluster.ts"
-        ],
+    ],
     visibility = ["//test/behaviour:__pkg__"],
 )
 

--- a/api/connection/user/User.ts
+++ b/api/connection/user/User.ts
@@ -23,7 +23,7 @@ export interface User {
 
     readonly username: string;
 
-    readonly passwordExpiryDays: number;
+    readonly passwordExpirySeconds: number;
 
     passwordUpdate(oldPassword: string, newPassword: string): Promise<void>;
 }

--- a/connection/cluster/ClusterUser.ts
+++ b/connection/cluster/ClusterUser.ts
@@ -30,23 +30,23 @@ export class ClusterUser implements User {
 
     private readonly _client: ClusterClient;
     private readonly _username: string;
-    private readonly _passwordExpiryDays: number;
+    private readonly _passwordExpirySeconds: number;
 
-    constructor(client: ClusterClient, username: string, passwordExpiryDays: number) {
+    constructor(client: ClusterClient, username: string, passwordExpirySeconds: number) {
         this._client = client;
         this._username = username;
-        this._passwordExpiryDays = passwordExpiryDays;
+        this._passwordExpirySeconds = passwordExpirySeconds;
     }
 
     static of(user: UserProto, client: ClusterClient): ClusterUser {
         switch (user.getPasswordExpiryCase()) {
             case UserProto.PasswordExpiryCase.PASSWORD_EXPIRY_NOT_SET: return new ClusterUser(client, user.getUsername(), null);
-            case UserProto.PasswordExpiryCase.PASSWORD_EXPIRY_DAYS: return new ClusterUser(client, user.getUsername(), user.getPasswordExpiryDays());
+            case UserProto.PasswordExpiryCase.PASSWORD_EXPIRY_SECONDS: return new ClusterUser(client, user.getUsername(), user.getpasswordExpirySeconds());
         }
     }
 
-    get passwordExpiryDays(): number {
-        return this._passwordExpiryDays;
+    get passwordExpirySeconds(): number {
+        return this._passwordExpirySeconds;
     }
 
     async passwordUpdate(oldPassword: string, newPassword: string): Promise<void> {

--- a/connection/cluster/ClusterUser.ts
+++ b/connection/cluster/ClusterUser.ts
@@ -41,7 +41,7 @@ export class ClusterUser implements User {
     static of(user: UserProto, client: ClusterClient): ClusterUser {
         switch (user.getPasswordExpiryCase()) {
             case UserProto.PasswordExpiryCase.PASSWORD_EXPIRY_NOT_SET: return new ClusterUser(client, user.getUsername(), null);
-            case UserProto.PasswordExpiryCase.PASSWORD_EXPIRY_SECONDS: return new ClusterUser(client, user.getUsername(), user.getpasswordExpirySeconds());
+            case UserProto.PasswordExpiryCase.PASSWORD_EXPIRY_SECONDS: return new ClusterUser(client, user.getUsername(), user.getPasswordExpirySeconds());
         }
     }
 

--- a/dependencies/vaticle/artifacts.bzl
+++ b/dependencies/vaticle/artifacts.bzl
@@ -29,7 +29,7 @@ def vaticle_typedb_artifacts():
         artifact_name = "typedb-server-{platform}-{version}.{ext}",
         tag_source = deployment["artifact.release"],
         commit_source = deployment["artifact.snapshot"],
-        tag = "2.16.1",
+        commit = "c36d4deeb6a7f9b53dced92002e57c1df9963f7a",
     )
 
 def vaticle_typedb_cluster_artifacts():
@@ -39,5 +39,5 @@ def vaticle_typedb_cluster_artifacts():
         artifact_name = "typedb-cluster-all-{platform}-{version}.{ext}",
         tag_source = deployment_private["artifact.release"],
         commit_source = deployment_private["artifact.snapshot"],
-        tag = "2.16.1",
+        commit = "230757ad05e2b1a8cf78a3cb67d90d759de64a19",
     )

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -25,7 +25,7 @@ def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
         remote = "https://github.com/vaticle/dependencies",
-        commit = "0daf20ca5efc141fc8e3f9a767a9118b6eee0980", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        commit = "e0446ffa70cacca89cb1faa2cd6f299c3784d845", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 #TODO: MOVE NATIVE_TYPEDB_ARTIFACT INTO DEPENDENCIES, THEN REMOVE THIS DEPENDENCY
@@ -33,12 +33,12 @@ def vaticle_typedb_common():
     git_repository(
         name = "vaticle_typedb_common",
         remote = "https://github.com/vaticle/typedb-common",
-        tag = "2.16.0" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
+        tag = "2.17.0" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
     )
 
 def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
         remote = "https://github.com/vaticle/typedb-behaviour",
-        commit = "ff4f58b4db2200b907c60b28a2b8ee661449e9c0" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        commit = "f98a17c9644a1fdae0c066273fdde2027d5e6299" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -40,5 +40,5 @@ def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
         remote = "https://github.com/vaticle/typedb-behaviour",
-        commit = "f98a17c9644a1fdae0c066273fdde2027d5e6299" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        commit = "b4cbdd3aaf28428608fc88eae0852425df57fe25" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@grpc/grpc-js": "1.5.0",
     "google-protobuf": "3.19.3",
-    "typedb-protocol": "2.16.1",
+    "typedb-protocol": "2.16.3",
     "uuid": "8.3.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@grpc/grpc-js": "1.5.0",
     "google-protobuf": "3.19.3",
-    "typedb-protocol": "2.16.3",
+    "typedb-protocol": "2.17.0",
     "uuid": "8.3.2"
   },
   "devDependencies": {

--- a/test/behaviour/concept/type/thingtype/ThingTypeSteps.ts
+++ b/test/behaviour/concept/type/thingtype/ThingTypeSteps.ts
@@ -35,6 +35,8 @@ export function getThingType(rootLabel: RootLabel, typeLabel: string): Promise<T
             return tx().concepts.getAttributeType(typeLabel);
         case RootLabel.RELATION:
             return tx().concepts.getRelationType(typeLabel);
+        case RootLabel.THING:
+            return tx().concepts.getRootThingType();
         default:
             throw "Unsupported type"
     }
@@ -131,6 +133,8 @@ When("{root_label}\\({type_label}) set supertype: {type_label}", async (rootLabe
             const relationSuperType = await tx().concepts.getRelationType(superLabel);
             return await (await tx().concepts.getRelationType(typeLabel)).asRemote(tx()).setSupertype(relationSuperType);
         }
+        default:
+            throw "Unsupported type"
     }
 });
 
@@ -148,6 +152,8 @@ When("{root_label}\\({type_label}) set supertype: {type_label}; throws exception
             const relationSuperType = await tx().concepts.getRelationType(superLabel);
             return await assertThrows(async () => await (await tx().concepts.getRelationType(typeLabel)).asRemote(tx()).setSupertype(relationSuperType));
         }
+        default:
+            throw "Unsupported type"
     }
 });
 

--- a/test/behaviour/config/Parameters.ts
+++ b/test/behaviour/config/Parameters.ts
@@ -47,8 +47,14 @@ defineParameterType({
 });
 
 defineParameterType({
+    name: "words",
+    regexp: /[\w-_]+/,
+    transformer: s => s
+})
+
+defineParameterType({
     name: "root_label",
-    regexp: /entity|attribute|relation/,
+    regexp: /entity|attribute|relation|thing/,
     transformer: s => {
         switch (s) {
             case "entity":
@@ -57,6 +63,8 @@ defineParameterType({
                 return RootLabel.ATTRIBUTE;
             case "relation":
                 return RootLabel.RELATION;
+            case "thing":
+                return RootLabel.THING;
             default:
                 throw `Root label "${s}" was unrecognised.`
         }
@@ -143,6 +151,7 @@ export enum RootLabel {
     ATTRIBUTE,
     ENTITY,
     RELATION,
+    THING,
 }
 
 export function parseList(dataTable: DataTable): string[]

--- a/test/behaviour/connection/ConnectionStepsBase.ts
+++ b/test/behaviour/connection/ConnectionStepsBase.ts
@@ -105,6 +105,10 @@ Given('connection opens with authentication: {words}, {words}', async (username:
     await createClient(username, password);
 })
 
+Given('Connection closes', async () => {
+    if (client && client.isOpen()) await client.close();
+})
+
 Given('connection opens with authentication: {words}, {words}; throws exception', async (username: string, password: string) => {
     await assertThrows(() => createClient(username, password));
 })

--- a/test/behaviour/connection/ConnectionStepsBase.ts
+++ b/test/behaviour/connection/ConnectionStepsBase.ts
@@ -58,7 +58,7 @@ export function setDefaultClientFn(constructor: () => Promise<TypeDBClient>) {
     defaultClientFn = constructor;
 }
 
-export async function createDefaultClient() {
+export async function createDefaultClient(): Promise<void> {
     client = await defaultClientFn();
 }
 

--- a/test/behaviour/connection/ConnectionStepsBase.ts
+++ b/test/behaviour/connection/ConnectionStepsBase.ts
@@ -105,7 +105,7 @@ Given('connection opens with authentication: {words}, {words}', async (username:
     await createClient(username, password);
 })
 
-Given('Connection closes', async () => {
+Given('connection closes', async () => {
     if (client && client.isOpen()) await client.close();
 })
 

--- a/test/behaviour/connection/ConnectionStepsBase.ts
+++ b/test/behaviour/connection/ConnectionStepsBase.ts
@@ -22,12 +22,16 @@
 import {Given, setDefaultTimeout, Then} from "@cucumber/cucumber";
 import {TypeDBClient, TypeDBSession, TypeDBTransaction, TypeDBOptions} from "../../../dist";
 import assert = require("assert");
+import {assertThrows} from "../util/Util";
 
 interface OptionSetters {
-    [index: string] : (options: TypeDBOptions, value: string) => void
+    [index: string]: (options: TypeDBOptions, value: string) => void
 }
 
 export const THREAD_POOL_SIZE = 32;
+
+export let clientFn: (username: string, password: string) => Promise<TypeDBClient>;
+export let defaultClientFn: () => Promise<TypeDBClient>;
 
 export let client: TypeDBClient;
 export const sessions: TypeDBSession[] = [];
@@ -46,8 +50,20 @@ export function tx(): TypeDBTransaction {
     return sessionsToTransactions.get(sessions[0])[0];
 }
 
-export function setClient(value: TypeDBClient) {
-    client = value;
+export function setClientFn(constructor: (username: string, password: string) => Promise<TypeDBClient>) {
+    clientFn = constructor;
+}
+
+export function setDefaultClientFn(constructor: () => Promise<TypeDBClient>) {
+    defaultClientFn = constructor;
+}
+
+export async function createDefaultClient() {
+    client = await defaultClientFn();
+}
+
+export async function createClient(username: string, password: string) {
+    client = await clientFn(username, password);
 }
 
 export function setSessionOptions(options: TypeDBOptions) {
@@ -59,29 +75,43 @@ export function setTransactionOptions(options: TypeDBOptions) {
 }
 
 export async function afterAllBase(): Promise<void> {
-    await client.close();
+
 }
 
 export async function beforeBase(): Promise<void> {
-    for (const session of sessions) {
-        assert(!session.isOpen());
-    }
-    const databases = await client.databases.all();
-    for (const db of databases) {
-        await db.delete();
-    }
     sessions.length = 0;
     sessionsToTransactions.clear();
 }
 
 export async function afterBase() {
-    for (const session of sessions) {
-        await session.close()
-    }
-    for (const db of await client.databases.all()) {
-        await db.delete();
+    if (client.isOpen()) {
+        await client.close();
     }
 }
+
+Given('typedb has configuration', (table: any) => {
+    // TODO: prepare a configuration through the TypeDB runner once it exists
+})
+
+Given('typedb starts', async () => {
+    // TODO: start TypeDB through the TypeDB runner once it exists
+})
+
+Given('typedb stops', async () => {
+    // TODO: stop TypeDB through the TypeDB runner once it exists
+})
+
+Given('connection opens with default authentication', async () => {
+    await createDefaultClient();
+})
+
+Given('connection opens with authentication: {words}, {words}', async (username: string, password: string) => {
+    await createClient(username, password);
+})
+
+Given('connection opens with authentication: {words}, {words}; throws exception', async (username: string, password: string) => {
+    await assertThrows(() => createClient(username, password));
+})
 
 Given('connection has been opened', () => {
     assert(client);

--- a/test/behaviour/connection/ConnectionStepsBase.ts
+++ b/test/behaviour/connection/ConnectionStepsBase.ts
@@ -74,10 +74,6 @@ export function setTransactionOptions(options: TypeDBOptions) {
     transactionOptions = options;
 }
 
-export async function afterAllBase(): Promise<void> {
-
-}
-
 export async function beforeBase(): Promise<void> {
     sessions.length = 0;
     sessionsToTransactions.clear();

--- a/test/behaviour/connection/ConnectionStepsCluster.ts
+++ b/test/behaviour/connection/ConnectionStepsCluster.ts
@@ -48,7 +48,6 @@ AfterAll(async () => {
 
 Before(async () => {
     await beforeBase();
-
 });
 
 After(async() => {
@@ -60,7 +59,7 @@ After(async() => {
         await db.delete();
     }
     assert(client.isCluster());
-    const users = await (client as TypeDBClient.Cluster).users().all();
+    const users = await (client as TypeDBClient.Cluster).users.all();
     for (const user of users) {
         await (client as TypeDBClient.Cluster).users.delete(user.username);
     }

--- a/test/behaviour/connection/ConnectionStepsCluster.ts
+++ b/test/behaviour/connection/ConnectionStepsCluster.ts
@@ -42,9 +42,6 @@ BeforeAll(async () => {
     setTransactionOptions(TypeDBOptions.cluster({"infer": true}));
 });
 
-AfterAll(async () => {
-    await afterAllBase()
-});
 
 Before(async () => {
     await beforeBase();

--- a/test/behaviour/connection/ConnectionStepsCluster.ts
+++ b/test/behaviour/connection/ConnectionStepsCluster.ts
@@ -34,25 +34,29 @@ import {
 import assert from "assert";
 
 BeforeAll(async () => {
-    setDefaultClientFn(() =>
+    setDefaultClientFn(async () =>
         TypeDB.clusterClient([TypeDB.DEFAULT_ADDRESS], new TypeDBCredential("admin", "password", process.env.ROOT_CA))
     )
-    setClientFn((username, password) => {
+    setClientFn(async (username, password) => {
         return TypeDB.clusterClient([TypeDB.DEFAULT_ADDRESS], new TypeDBCredential(username, password, process.env.ROOT_CA))
     });
     setSessionOptions(TypeDBOptions.cluster({"infer": true}));
     setTransactionOptions(TypeDBOptions.cluster({"infer": true}));
 });
 
-
 Before(async () => {
     await beforeBase();
+    await clearDB();
 });
 
-After(async() => {
-    await afterBase()
+After(async () => {
+    await afterBase();
+    await clearDB()
+});
+
+async function clearDB() {
     // TODO: reset the database through the TypeDB runner once it exists
-    createDefaultClient();
+    await createDefaultClient();
     const databases = await client.databases.all();
     for (const db of databases) {
         await db.delete();
@@ -63,4 +67,4 @@ After(async() => {
         await (client as TypeDBClient.Cluster).users.delete(user.username);
     }
     await client.close();
-});
+}

--- a/test/behaviour/connection/ConnectionStepsCluster.ts
+++ b/test/behaviour/connection/ConnectionStepsCluster.ts
@@ -19,13 +19,15 @@
  * under the License.
  */
 
-import {After, AfterAll, Before, BeforeAll} from "@cucumber/cucumber";
-import {TypeDBClient, TypeDB, TypeDBCredential, TypeDBOptions} from "../../../dist";
+import {After, Before, BeforeAll} from "@cucumber/cucumber";
+import {TypeDB, TypeDBClient, TypeDBCredential, TypeDBOptions} from "../../../dist";
 import {
-    afterAllBase,
     afterBase,
-    beforeBase, client, createDefaultClient,
-    setClientFn, setDefaultClientFn,
+    beforeBase,
+    client,
+    createDefaultClient,
+    setClientFn,
+    setDefaultClientFn,
     setSessionOptions,
     setTransactionOptions
 } from "./ConnectionStepsBase";

--- a/test/behaviour/connection/ConnectionStepsCluster.ts
+++ b/test/behaviour/connection/ConnectionStepsCluster.ts
@@ -20,18 +20,26 @@
  */
 
 import {After, AfterAll, Before, BeforeAll} from "@cucumber/cucumber";
-import {TypeDB, TypeDBCredential, TypeDBOptions} from "../../../dist";
+import {TypeDBClient, TypeDB, TypeDBCredential, TypeDBOptions} from "../../../dist";
 import {
     afterAllBase,
     afterBase,
-    beforeBase,
-    setClient,
+    beforeBase, client, createDefaultClient,
+    setClientFn, setDefaultClientFn,
     setSessionOptions,
     setTransactionOptions
 } from "./ConnectionStepsBase";
+import assert from "assert";
 
 BeforeAll(async () => {
-    setClient(await TypeDB.clusterClient([TypeDB.DEFAULT_ADDRESS], new TypeDBCredential("admin", "password", process.env.ROOT_CA)));
+    setDefaultClientFn(() =>
+        TypeDB.clusterClient([TypeDB.DEFAULT_ADDRESS], new TypeDBCredential("admin", "password", process.env.ROOT_CA))
+    )
+    setClientFn((username, password) => {
+        return TypeDB.clusterClient([TypeDB.DEFAULT_ADDRESS], new TypeDBCredential(username, password, process.env.ROOT_CA))
+    });
+    setSessionOptions(TypeDBOptions.cluster({"infer": true}));
+    setTransactionOptions(TypeDBOptions.cluster({"infer": true}));
 });
 
 AfterAll(async () => {
@@ -40,10 +48,21 @@ AfterAll(async () => {
 
 Before(async () => {
     await beforeBase();
-    setSessionOptions(TypeDBOptions.cluster({"infer": true}));
-    setTransactionOptions(TypeDBOptions.cluster({"infer": true}));
+
 });
 
 After(async() => {
     await afterBase()
+    // TODO: reset the database through the TypeDB runner once it exists
+    createDefaultClient();
+    const databases = await client.databases.all();
+    for (const db of databases) {
+        await db.delete();
+    }
+    assert(client.isCluster());
+    const users = await (client as TypeDBClient.Cluster).users().all();
+    for (const user of users) {
+        await (client as TypeDBClient.Cluster).users.delete(user.username);
+    }
+    await client.close();
 });

--- a/test/behaviour/connection/ConnectionStepsCluster.ts
+++ b/test/behaviour/connection/ConnectionStepsCluster.ts
@@ -64,7 +64,9 @@ async function clearDB() {
     assert(client.isCluster());
     const users = await (client as TypeDBClient.Cluster).users.all();
     for (const user of users) {
-        await (client as TypeDBClient.Cluster).users.delete(user.username);
+        if (user.username != "admin") {
+            await (client as TypeDBClient.Cluster).users.delete(user.username);
+        }
     }
     await client.close();
 }

--- a/test/behaviour/connection/ConnectionStepsCore.ts
+++ b/test/behaviour/connection/ConnectionStepsCore.ts
@@ -39,9 +39,6 @@ BeforeAll(() => {
     setTransactionOptions(TypeDBOptions.core({"infer": true}));
 });
 
-AfterAll(async () => {
-    await afterAllBase()
-});
 
 Before(async () => {
     await beforeBase();

--- a/test/behaviour/connection/ConnectionStepsCore.ts
+++ b/test/behaviour/connection/ConnectionStepsCore.ts
@@ -19,13 +19,15 @@
  * under the License.
  */
 
-import {After, AfterAll, Before, BeforeAll} from "@cucumber/cucumber";
-import {TypeDB, TypeDBOptions, TypeDBClient} from "../../../dist";
+import {After, Before, BeforeAll} from "@cucumber/cucumber";
+import {TypeDB, TypeDBClient, TypeDBOptions} from "../../../dist";
 import {
-    afterAllBase,
     afterBase,
-    beforeBase, client, createDefaultClient,
-    setClientFn, setDefaultClientFn,
+    beforeBase,
+    client,
+    createDefaultClient,
+    setClientFn,
+    setDefaultClientFn,
     setSessionOptions,
     setTransactionOptions
 } from "./ConnectionStepsBase";

--- a/test/behaviour/connection/ConnectionStepsCore.ts
+++ b/test/behaviour/connection/ConnectionStepsCore.ts
@@ -31,12 +31,13 @@ import {
     setSessionOptions,
     setTransactionOptions
 } from "./ConnectionStepsBase";
+import assert from "assert";
 
 BeforeAll(() => {
-    setClientFn((username, password) => {
+    setClientFn(async (username, password) => {
         throw new Error("Core client does not support authentication");
     });
-    setDefaultClientFn(() => new Promise<TypeDBClient>((resolve, reject) => resolve(TypeDB.coreClient())));
+    setDefaultClientFn(async () => new Promise<TypeDBClient>((resolve, reject) => resolve(TypeDB.coreClient())));
     setSessionOptions(TypeDBOptions.core({"infer": true}));
     setTransactionOptions(TypeDBOptions.core({"infer": true}));
 });
@@ -44,15 +45,20 @@ BeforeAll(() => {
 
 Before(async () => {
     await beforeBase();
+    await clearDB();
 });
 
 After(async () => {
-    await afterBase()
+    await afterBase();
+    await clearDB()
+});
+
+async function clearDB() {
     // TODO: reset the database through the TypeDB runner once it exists
-    createDefaultClient();
+    await createDefaultClient();
     const databases = await client.databases.all();
     for (const db of databases) {
         await db.delete();
     }
     await client.close();
-});
+}

--- a/test/behaviour/connection/ConnectionStepsCore.ts
+++ b/test/behaviour/connection/ConnectionStepsCore.ts
@@ -20,7 +20,7 @@
  */
 
 import {After, AfterAll, Before, BeforeAll} from "@cucumber/cucumber";
-import {TypeDB, TypeDBOptions} from "../../../dist";
+import {TypeDB, TypeDBOptions, TypeDBClient} from "../../../dist";
 import {
     afterAllBase,
     afterBase,
@@ -34,7 +34,7 @@ BeforeAll(() => {
     setClientFn((username, password) => {
         throw new Error("Core client does not support authentication");
     });
-    setDefaultClientFn(() => TypeDB.coreClient());
+    setDefaultClientFn(() => new Promise<TypeDBClient>((resolve, reject) => resolve(TypeDB.coreClient())));
     setSessionOptions(TypeDBOptions.core({"infer": true}));
     setTransactionOptions(TypeDBOptions.core({"infer": true}));
 });

--- a/test/behaviour/connection/user/UserSteps.ts
+++ b/test/behaviour/connection/user/UserSteps.ts
@@ -67,6 +67,10 @@ Then("users delete: {words}", async (username: string) => {
     await getClient().users.delete(username);
 });
 
+Then("users delete: {words}; throws exception", async (username: string) => {
+    await assertThrows(() => getClient().users.delete(username));
+});
+
 Then("users password set: {words}, {words}", async (username: string, password: string) => {
     await getClient().users.passwordSet(username, password);
 });

--- a/test/behaviour/connection/user/UserSteps.ts
+++ b/test/behaviour/connection/user/UserSteps.ts
@@ -19,42 +19,66 @@
  * under the License.
  */
 
-import { Given, Then } from "@cucumber/cucumber";
-import { TypeDB, TypeDBClient, TypeDBCredential, User } from "../../../../dist"
-import { client } from "../ConnectionStepsBase";
+import {Given, Then} from "@cucumber/cucumber";
+import {TypeDB, TypeDBClient, TypeDBCredential, User} from "../../../../dist"
+import {client} from "../ConnectionStepsBase";
 import assert = require("assert");
+import {assertThrows} from "../../util/Util";
 
-Given("users contains: {word}", async (username: string) => {
+Then("users contains: {words}", async (username: string) => {
     const users = await getClient().users.all();
     users.map((user: User) => user.username).includes(username);
 });
 
-Then("users not contains: {word}", async (username: string) => {
+Then("users contains: {words}; throws exception", async (username: string) => {
+    await assertThrows(() => getClient().users.all());
+});
+
+Then("users not contains: {words}", async (username: string) => {
     const users = await getClient().users.all();
     !users.map((user: User) => user.username).includes(username);
 });
 
-Then("users create: {word}, {word}", async (username: string, password: string) => {
+Then("users create: {words}, {words}", async (username: string, password: string) => {
     await getClient().users.create(username, password);
 });
 
-Then("users delete: {word}", async (username: string) => {
+Then("users create: {words}, {words}; throws exception", async (username: string, password: string) => {
+    await assertThrows(() => getClient().users.create(username, password));
+});
+
+Then('users get all', async () => {
+    await getClient().users.all();
+});
+
+Then('users get all; throws exception', async () => {
+    await assertThrows(() => getClient().users.all());
+});
+
+Then('users get user: {words}', async (username: string) => {
+    await getClient().users.get(username);
+});
+
+Then('users get user: {words}; throws exception', async (username: string) => {
+    await assertThrows(() => getClient().users.get(username));
+});
+
+Then("users delete: {words}", async (username: string) => {
     await getClient().users.delete(username);
 });
 
-Then("users password set: {word}, {word}", async (username: string, password: string) => {
+Then("users password set: {words}, {words}", async (username: string, password: string) => {
     await getClient().users.passwordSet(username, password);
+});
+
+Then("users password set: {words}, {words}; throws exception", async (username: string, password: string) => {
+    await assertThrows(() => getClient().users.passwordSet(username, password));
 });
 
 Then("user password update: {word}, {word}, {word}", async (username: string, passwordOld: string, passwordNew: string) => {
     const user = await getClient().users.get(username);
     await user.passwordUpdate(passwordOld, passwordNew);
 });
-
-Then("user connect: {word}, {word}", async (username: string, password: string) => {
-    const client = await TypeDB.clusterClient([TypeDB.DEFAULT_ADDRESS], new TypeDBCredential(username, password, process.env.ROOT_CA));
-    await client.databases.all()
-})
 
 function getClient(): TypeDBClient.Cluster {
     assert(client.isCluster());

--- a/test/behaviour/cucumber_test.sh
+++ b/test/behaviour/cucumber_test.sh
@@ -83,7 +83,7 @@ if [[ $STARTED -eq 0 ]]; then
   exit 1
 fi
 echo TypeDB $PRODUCT database server started
-node ./node_modules/.bin/cucumber-js ./external/vaticle_typedb_behaviour/**/*.feature --require './**/*.js' --tags 'not @ignore and not @ignore-typedb-client-nodejs' --format @cucumber/pretty-formatter && export RESULT=0 || export RESULT=1
+node ./node_modules/.bin/cucumber-js ./external/vaticle_typedb_behaviour/**/*.feature --require './**/*.js' --tags 'not @ignore and not @ignore-typedb-client-nodejs and not @ignore-client-nodejs' --format @cucumber/pretty-formatter && export RESULT=0 || export RESULT=1
 echo Tests concluded with exit value $RESULT
 echo Stopping server.
 kill $(lsof -i :1729 | awk '/java/ {print $2}')

--- a/yarn.lock
+++ b/yarn.lock
@@ -4246,10 +4246,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typedb-protocol@2.16.1:
-  version "2.16.1"
-  resolved "https://registry.yarnpkg.com/typedb-protocol/-/typedb-protocol-2.16.1.tgz#175d07d6668858d4460d7bda60f89fa564c3e4eb"
-  integrity sha512-q+5h+DUCzLGAd4mjsPSFeUo1uDWA7qPTlx7j9tZH3Hs1CR0poGZfJejhzn3id4CUC4BKlcdxg5ItDgcjZJqGtQ==
+typedb-protocol@2.17.0:
+  version "2.17.0"
+  resolved "https://registry.yarnpkg.com/typedb-protocol/-/typedb-protocol-2.17.0.tgz#7d8581ca5ccf8f7b2bb9a5596009e50985432073"
+  integrity sha512-Q0lR095BBv8d+gmVyDowVrsMlz4rigdZhhcgsGa0Yi6RvZgB+ZAY9M78HPIjIw4Lig4gZ43syVgV04/QWGufHQ==
   dependencies:
     "@grpc/grpc-js" "1.5.0"
 


### PR DESCRIPTION
## What is the goal of this PR?

We've redefined the way we expose how long until a password expires in seconds, rather than days as was done previously.

## What are the changes implemented in this PR?

* We've changed `password_expiry_days` to `password_expiry_seconds`.
* We implement the newly updated BDD steps to do with opening and closing connections, and prepare other steps for booting and configuring TypeDB for use once the TypeDB runner is available in Python
