### PR TITLE
Add method to Cluster client to retrieve current user

### DIFF
--- a/api/connection/TypeDBClient.ts
+++ b/api/connection/TypeDBClient.ts
@@ -23,6 +23,7 @@ import { DatabaseManager } from "./database/DatabaseManager";
 import { TypeDBOptions } from "./TypeDBOptions";
 import { SessionType, TypeDBSession } from "./TypeDBSession";
 import { UserManager } from "./user/UserManager";
+import { User } from "./user/User";
 
 export interface TypeDBClient {
 
@@ -42,6 +43,8 @@ export interface TypeDBClient {
 export namespace TypeDBClient {
 
     export interface Cluster extends TypeDBClient {
+
+        user(): Promise<User>;
 
         readonly users: UserManager;
 

--- a/connection/cluster/ClusterClient.ts
+++ b/connection/cluster/ClusterClient.ts
@@ -31,6 +31,7 @@ import { ClusterDatabaseManager } from "./ClusterDatabaseManager";
 import { ClusterServerClient } from "./ClusterServerClient";
 import { ClusterServerStub } from "./ClusterServerStub";
 import { ClusterSession } from "./ClusterSession";
+import { ClusterUser } from "./ClusterUser";
 import { ClusterUserManager } from "./ClusterUserManager";
 import { FailsafeTask } from "./FailsafeTask";
 import CLUSTER_UNABLE_TO_CONNECT = ErrorMessage.Client.CLUSTER_UNABLE_TO_CONNECT;
@@ -70,6 +71,10 @@ export class ClusterClient implements TypeDBClient.Cluster {
 
     isOpen(): boolean {
         return this._isOpen;
+    }
+
+    async user(): Promise<ClusterUser> {
+        return await this.users.get(this._credential.username)
     }
 
     get users(): ClusterUserManager {

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -39,6 +39,6 @@ def vaticle_typedb_common():
 def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
-        remote = "https://github.com/jamesreprise/typedb-behaviour",
-        commit = "04973b8312a78b1445ab6011f3b094585cfd9acf" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        remote = "https://github.com/vaticle/typedb-behaviour",
+        commit = "fbba9fc19042460760b852b765d356c9b3f4ebf0" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -39,6 +39,6 @@ def vaticle_typedb_common():
 def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
-        remote = "https://github.com/vaticle/typedb-behaviour",
-        commit = "b4cbdd3aaf28428608fc88eae0852425df57fe25" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        remote = "https://github.com/jamesreprise/typedb-behaviour",
+        commit = "455159dd1cdd8ab49e72e10d4c464209f2181424" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -40,5 +40,5 @@ def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
         remote = "https://github.com/jamesreprise/typedb-behaviour",
-        commit = "455159dd1cdd8ab49e72e10d4c464209f2181424" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        commit = "04973b8312a78b1445ab6011f3b094585cfd9acf" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )

--- a/test/behaviour/connection/user/UserSteps.ts
+++ b/test/behaviour/connection/user/UserSteps.ts
@@ -25,6 +25,10 @@ import {client} from "../ConnectionStepsBase";
 import assert = require("assert");
 import {assertThrows} from "../../util/Util";
 
+Then("user get self", async () => {
+    await getClient().user();
+});
+
 Then("users contains: {words}", async (username: string) => {
     const users = await getClient().users.all();
     users.map((user: User) => user.username).includes(username);

--- a/test/behaviour/connection/user/UserSteps.ts
+++ b/test/behaviour/connection/user/UserSteps.ts
@@ -25,7 +25,7 @@ import {client} from "../ConnectionStepsBase";
 import assert = require("assert");
 import {assertThrows} from "../../util/Util";
 
-Then("user get self", async () => {
+Then("get connected user", async () => {
     await getClient().user();
 });
 


### PR DESCRIPTION
## What is the goal of this PR?

Add an API to be able retrieve the currently authenticated user.

## What are the changes implemented in this PR?

Added functions:
* `user(): Promise<User>` to the `TypeDBClient.Cluster` interface.
* `async user(): Promise<ClusterUser>` to the `ClusterClient` class.

Added user step: `get connected user`.