### PR TITLE
Introduce Values to support expressions

### DIFF
--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -112,6 +112,7 @@ build:
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
         .factory/test-core.sh //test/behaviour/typeql/language/match/... --test_output=errors --jobs=1
         .factory/test-core.sh //test/behaviour/typeql/language/get/... --test_output=errors --jobs=1
+        .factory/test-core.sh //test/behaviour/typeql/language/expression/... --test_output=errors --jobs=1
     test-behaviour-match-cluster:
       image: vaticle-ubuntu-22.04
       command: |
@@ -120,6 +121,7 @@ build:
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
         .factory/test-cluster.sh //test/behaviour/typeql/language/match/... --test_output=errors --jobs=1
         .factory/test-cluster.sh //test/behaviour/typeql/language/get/... --test_output=errors --jobs=1
+        .factory/test-cluster.sh //test/behaviour/typeql/language/expression/... --test_output=errors --jobs=1
     test-behaviour-writable-core:
       image: vaticle-ubuntu-22.04
       command: |

--- a/BUILD
+++ b/BUILD
@@ -227,7 +227,6 @@ checkstyle_test(
 filegroup(
     name = "ci",
     data = [
-        "@vaticle_dependencies//tool/bazelrun:rbe",
         "@vaticle_dependencies//distribution/artifact:create-netrc",
         "@vaticle_dependencies//tool/release/notes:create",
     ],

--- a/api/concept/Concept.ts
+++ b/api/concept/Concept.ts
@@ -31,7 +31,7 @@ import { RelationType } from "./type/RelationType";
 import { RoleType } from "./type/RoleType";
 import { ThingType } from "./type/ThingType";
 import { Type } from "./type/Type";
-import {AttributeType as ConceptProto} from "typedb-protocol/common/concept_pb";
+import {ValueType as ValueTypeProto} from "typedb-protocol/common/concept_pb";
 import {Value} from "./value/Value";
 
 export interface Concept {
@@ -121,7 +121,7 @@ export namespace Concept {
 
     export interface ValueType {
 
-        proto(): ConceptProto.ValueType;
+        proto(): ValueTypeProto;
 
         name(): string;
     }
@@ -130,15 +130,15 @@ export namespace Concept {
 
         class Impl implements ValueType {
 
-            private readonly _proto: ConceptProto.ValueType;
+            private readonly _proto: ValueTypeProto;
             private readonly _name: string;
 
-            constructor(type: ConceptProto.ValueType, name: string) {
+            constructor(type: ValueTypeProto, name: string) {
                 this._proto = type;
                 this._name = name;
             }
 
-            proto(): ConceptProto.ValueType {
+            proto(): ValueTypeProto {
                 return this._proto;
             }
 
@@ -151,11 +151,11 @@ export namespace Concept {
             }
         }
 
-        export const OBJECT = new Impl(ConceptProto.ValueType.OBJECT, "OBJECT");
-        export const BOOLEAN = new Impl(ConceptProto.ValueType.BOOLEAN, "BOOLEAN");
-        export const LONG = new Impl(ConceptProto.ValueType.LONG, "LONG");
-        export const DOUBLE = new Impl(ConceptProto.ValueType.DOUBLE, "DOUBLE");
-        export const STRING = new Impl(ConceptProto.ValueType.STRING, "STRING");
-        export const DATETIME = new Impl(ConceptProto.ValueType.DATETIME, "DATETIME");
+        export const OBJECT = new Impl(ValueTypeProto.OBJECT, "OBJECT");
+        export const BOOLEAN = new Impl(ValueTypeProto.BOOLEAN, "BOOLEAN");
+        export const LONG = new Impl(ValueTypeProto.LONG, "LONG");
+        export const DOUBLE = new Impl(ValueTypeProto.DOUBLE, "DOUBLE");
+        export const STRING = new Impl(ValueTypeProto.STRING, "STRING");
+        export const DATETIME = new Impl(ValueTypeProto.DATETIME, "DATETIME");
     }
 }

--- a/api/concept/Concept.ts
+++ b/api/concept/Concept.ts
@@ -31,6 +31,8 @@ import { RelationType } from "./type/RelationType";
 import { RoleType } from "./type/RoleType";
 import { ThingType } from "./type/ThingType";
 import { Type } from "./type/Type";
+import {AttributeType as ConceptProto} from "typedb-protocol/common/concept_pb";
+import {Value} from "./value/Value";
 
 export interface Concept {
 
@@ -58,6 +60,8 @@ export interface Concept {
 
     isRelation(): boolean;
 
+    isValue(): boolean;
+
     asType(): Type;
 
     asThingType(): ThingType;
@@ -77,6 +81,8 @@ export interface Concept {
     asAttribute(): Attribute;
 
     asRelation(): Relation;
+
+    asValue(): Value;
 
     equals(concept: Concept): boolean;
 
@@ -110,5 +116,46 @@ export namespace Concept {
         asAttribute(): Attribute.Remote;
 
         asRelation(): Relation.Remote;
+    }
+
+
+    export interface ValueType {
+
+        proto(): ConceptProto.ValueType;
+
+        name(): string;
+    }
+
+    export namespace ValueType {
+
+        class Impl implements ValueType {
+
+            private readonly _proto: ConceptProto.ValueType;
+            private readonly _name: string;
+
+            constructor(type: ConceptProto.ValueType, name: string) {
+                this._proto = type;
+                this._name = name;
+            }
+
+            proto(): ConceptProto.ValueType {
+                return this._proto;
+            }
+
+            name(): string {
+                return this._name.toLowerCase();
+            }
+
+            toString() {
+                return "ValueType[" + this._name + "]";
+            }
+        }
+
+        export const OBJECT = new Impl(ConceptProto.ValueType.OBJECT, "OBJECT");
+        export const BOOLEAN = new Impl(ConceptProto.ValueType.BOOLEAN, "BOOLEAN");
+        export const LONG = new Impl(ConceptProto.ValueType.LONG, "LONG");
+        export const DOUBLE = new Impl(ConceptProto.ValueType.DOUBLE, "DOUBLE");
+        export const STRING = new Impl(ConceptProto.ValueType.STRING, "STRING");
+        export const DATETIME = new Impl(ConceptProto.ValueType.DATETIME, "DATETIME");
     }
 }

--- a/api/concept/ConceptManager.ts
+++ b/api/concept/ConceptManager.ts
@@ -19,11 +19,12 @@
  * under the License.
  */
 
-import { Thing } from "./thing/Thing";
-import { AttributeType } from "./type/AttributeType";
-import { EntityType } from "./type/EntityType";
-import { RelationType } from "./type/RelationType";
-import { ThingType } from "./type/ThingType";
+import {Thing} from "./thing/Thing";
+import {AttributeType} from "./type/AttributeType";
+import {EntityType} from "./type/EntityType";
+import {RelationType} from "./type/RelationType";
+import {ThingType} from "./type/ThingType";
+import {Concept} from "./Concept";
 
 export interface ConceptManager {
 
@@ -49,5 +50,5 @@ export interface ConceptManager {
 
     getAttributeType(label: string): Promise<AttributeType>;
 
-    putAttributeType(label: string, valueType: AttributeType.ValueType): Promise<AttributeType>;
+    putAttributeType(label: string, valueType: Concept.ValueType): Promise<AttributeType>;
 }

--- a/api/concept/type/AttributeType.ts
+++ b/api/concept/type/AttributeType.ts
@@ -19,22 +19,23 @@
  * under the License.
  */
 
-import { AttributeType as AttributeTypeProto } from "typedb-protocol/common/concept_pb";
-import { Stream } from "../../../common/util/Stream";
-import { TypeDBTransaction } from "../../connection/TypeDBTransaction";
-import { Attribute } from "../thing/Attribute";
-import { Entity } from "../thing/Entity";
-import { Relation } from "../thing/Relation";
-import { Thing } from "../thing/Thing";
-import { EntityType } from "./EntityType";
-import { RelationType } from "./RelationType";
-import { RoleType } from "./RoleType";
-import { ThingType } from "./ThingType";
-import { Type } from "./Type";
+import {Stream} from "../../../common/util/Stream";
+import {TypeDBTransaction} from "../../connection/TypeDBTransaction";
+import {Attribute} from "../thing/Attribute";
+import {Entity} from "../thing/Entity";
+import {Relation} from "../thing/Relation";
+import {Thing} from "../thing/Thing";
+import {EntityType} from "./EntityType";
+import {RelationType} from "./RelationType";
+import {RoleType} from "./RoleType";
+import {ThingType} from "./ThingType";
+import {Type} from "./Type";
+import {Concept} from "../Concept";
+import Annotation = ThingType.Annotation;
 
 export interface AttributeType extends ThingType {
 
-    readonly valueType: AttributeType.ValueType;
+    readonly valueType: Concept.ValueType;
 
     isBoolean(): boolean;
 
@@ -61,8 +62,6 @@ export interface AttributeType extends ThingType {
 
 /* eslint @typescript-eslint/ban-types: "off" */
 export namespace AttributeType {
-
-    import Annotation = ThingType.Annotation;
 
     export interface Remote extends AttributeType, ThingType.Remote {
 
@@ -380,57 +379,5 @@ export namespace AttributeType {
 
             get(value: Date): Promise<Attribute.DateTime>;
         }
-    }
-
-    export interface ValueType {
-
-        isKeyable(): boolean;
-
-        isWritable(): boolean;
-
-        proto(): AttributeTypeProto.ValueType;
-
-        name(): string;
-    }
-
-    export namespace ValueType {
-
-        class Impl implements ValueType {
-
-            private readonly _attrTypeProto: AttributeTypeProto.ValueType;
-            private readonly _name: string;
-
-            constructor(type: AttributeTypeProto.ValueType, name: string) {
-                this._attrTypeProto = type;
-                this._name = name;
-            }
-
-            proto(): AttributeTypeProto.ValueType {
-                return this._attrTypeProto;
-            }
-
-            name(): string {
-                return this._name.toLowerCase();
-            }
-
-            isKeyable(): boolean {
-                return [AttributeTypeProto.ValueType.LONG, AttributeTypeProto.ValueType.STRING, AttributeTypeProto.ValueType.DATETIME].includes(this._attrTypeProto);
-            }
-
-            isWritable(): boolean {
-                return this._attrTypeProto !== AttributeTypeProto.ValueType.OBJECT;
-            }
-
-            toString() {
-                return "ValueType[" + this._name + "]";
-            }
-        }
-
-        export const OBJECT = new Impl(AttributeTypeProto.ValueType.OBJECT, "OBJECT");
-        export const BOOLEAN = new Impl(AttributeTypeProto.ValueType.BOOLEAN, "BOOLEAN");
-        export const LONG = new Impl(AttributeTypeProto.ValueType.LONG, "LONG");
-        export const DOUBLE = new Impl(AttributeTypeProto.ValueType.DOUBLE, "DOUBLE");
-        export const STRING = new Impl(AttributeTypeProto.ValueType.STRING, "STRING");
-        export const DATETIME = new Impl(AttributeTypeProto.ValueType.DATETIME, "DATETIME");
     }
 }

--- a/api/concept/type/ThingType.ts
+++ b/api/concept/type/ThingType.ts
@@ -23,6 +23,7 @@
 import {RequestBuilder} from "../../../common/rpc/RequestBuilder";
 import {Stream} from "../../../common/util/Stream";
 import {TypeDBTransaction} from "../../connection/TypeDBTransaction";
+import {Concept} from "../Concept";
 import {Attribute} from "../thing/Attribute";
 import {Entity} from "../thing/Entity";
 import {Relation} from "../thing/Relation";
@@ -136,19 +137,19 @@ export namespace ThingType {
 
         getOwns(): Stream<AttributeType>;
 
-        getOwns(valueType: AttributeType.ValueType): Stream<AttributeType>;
+        getOwns(valueType: Concept.ValueType): Stream<AttributeType>;
 
         getOwns(annotations: Annotation[]): Stream<AttributeType>;
 
-        getOwns(valueType: AttributeType.ValueType, annotations: Annotation[]): Stream<AttributeType>;
+        getOwns(valueType: Concept.ValueType, annotations: Annotation[]): Stream<AttributeType>;
 
         getOwnsExplicit(): Stream<AttributeType>;
 
-        getOwnsExplicit(valueType: AttributeType.ValueType): Stream<AttributeType>;
+        getOwnsExplicit(valueType: Concept.ValueType): Stream<AttributeType>;
 
         getOwnsExplicit(annotations: Annotation[]): Stream<AttributeType>;
 
-        getOwnsExplicit(valueType: AttributeType.ValueType, annotations: Annotation[]): Stream<AttributeType>;
+        getOwnsExplicit(valueType: Concept.ValueType, annotations: Annotation[]): Stream<AttributeType>;
 
         getOwnsOverridden(attributeType: AttributeType): Promise<AttributeType>;
 

--- a/api/concept/type/Type.ts
+++ b/api/concept/type/Type.ts
@@ -20,22 +20,22 @@
  */
 
 
-import { Type as TypeProto } from "typedb-protocol/common/concept_pb";
-import { ErrorMessage } from "../../../common/errors/ErrorMessage";
-import { TypeDBClientError } from "../../../common/errors/TypeDBClientError";
-import { Label } from "../../../common/Label";
-import { Stream } from "../../../common/util/Stream";
-import { TypeDBTransaction } from "../../connection/TypeDBTransaction";
-import { Concept } from "../Concept";
-import { Attribute } from "../thing/Attribute";
-import { Entity } from "../thing/Entity";
-import { Relation } from "../thing/Relation";
-import { Thing } from "../thing/Thing";
-import { AttributeType } from "./AttributeType";
-import { EntityType } from "./EntityType";
-import { RelationType } from "./RelationType";
-import { RoleType } from "./RoleType";
-import { ThingType } from "./ThingType";
+import {Type as TypeProto} from "typedb-protocol/common/concept_pb";
+import {ErrorMessage} from "../../../common/errors/ErrorMessage";
+import {TypeDBClientError} from "../../../common/errors/TypeDBClientError";
+import {Label} from "../../../common/Label";
+import {Stream} from "../../../common/util/Stream";
+import {TypeDBTransaction} from "../../connection/TypeDBTransaction";
+import {Concept} from "../Concept";
+import {Attribute} from "../thing/Attribute";
+import {Entity} from "../thing/Entity";
+import {Relation} from "../thing/Relation";
+import {Thing} from "../thing/Thing";
+import {AttributeType} from "./AttributeType";
+import {EntityType} from "./EntityType";
+import {RelationType} from "./RelationType";
+import {RoleType} from "./RoleType";
+import {ThingType} from "./ThingType";
 import BAD_ENCODING = ErrorMessage.Concept.BAD_ENCODING;
 
 export interface Type extends Concept {

--- a/api/concept/value/Value.ts
+++ b/api/concept/value/Value.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2022 Vaticle
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+import {Concept} from "../Concept";
+
+export interface Value extends Concept {
+
+    readonly valueType: Concept.ValueType;
+
+    readonly value: boolean | string | number | Date;
+
+    isBoolean(): boolean;
+
+    isLong(): boolean;
+
+    isDouble(): boolean;
+
+    isString(): boolean;
+
+    isDateTime(): boolean;
+
+    asBoolean(): Value.Boolean;
+
+    asLong(): Value.Long;
+
+    asDouble(): Value.Double;
+
+    asString(): Value.String;
+
+    asDateTime(): Value.DateTime;
+}
+
+export namespace Value {
+
+    export interface Boolean extends Value {
+
+        readonly value: boolean;
+
+    }
+
+    export interface Long extends Value {
+
+        readonly value: number;
+
+    }
+
+    export interface Double extends Value {
+
+        readonly value: number;
+
+    }
+
+    export interface String extends Value {
+
+        readonly value: string;
+
+    }
+
+    export interface DateTime extends Value {
+
+        readonly value: Date;
+
+    }
+}

--- a/common/errors/ErrorMessage.ts
+++ b/common/errors/ErrorMessage.ts
@@ -109,6 +109,7 @@ export namespace ErrorMessage {
         export const BAD_VALUE_TYPE = new Concept(6, (args: Stringable[]) => `The value type '${args[0]}' was not recognised.`);
         export const BAD_ANNOTATION = new Concept(7, (args: Stringable[]) => `The annotation '${args[0]}' was not recognised.`);
         export const BAD_ATTRIBUTE_VALUE = new Concept(8, (args: Stringable[]) => `The attribute value '${args[0]}' was not recognised.`);
+        export const VALUE_HAS_NO_REMOTE = new Concept(9, (args: Stringable[]) => `A 'value' has no remote concept.`);
     }
 
     export class Query extends ErrorMessage {

--- a/common/rpc/RequestBuilder.ts
+++ b/common/rpc/RequestBuilder.ts
@@ -19,19 +19,37 @@
  * under the License.
  */
 
-import { ClusterDatabaseManager } from "typedb-protocol/cluster/cluster_database_pb";
-import { ServerManager as ServerManagerProto } from "typedb-protocol/cluster/cluster_server_pb";
-import { ClusterUser as ClusterUserProto, ClusterUserManager as ClusterUserManagerProto } from "typedb-protocol/cluster/cluster_user_pb";
-import { Attribute as AttributeProto, AttributeType as AttributeTypeProto, ConceptManager as ConceptMgrProto, EntityType as EntityTypeProto, Relation as RelationProto, RelationType as RelationTypeProto, RoleType as RoleTypeProto, Thing as ThingProto, ThingType as ThingTypeProto, Type as TypeProto } from "typedb-protocol/common/concept_pb";
-import { LogicManager as LogicProto, Rule as RuleProto } from "typedb-protocol/common/logic_pb";
-import { Options } from "typedb-protocol/common/options_pb";
-import { QueryManager as QueryProto } from "typedb-protocol/common/query_pb";
-import { Session as SessionProto } from "typedb-protocol/common/session_pb";
-import { Transaction as TransactionProto } from "typedb-protocol/common/transaction_pb";
-import { CoreDatabase, CoreDatabaseManager } from "typedb-protocol/core/core_database_pb";
+import {ClusterDatabaseManager} from "typedb-protocol/cluster/cluster_database_pb";
+import {ServerManager as ServerManagerProto} from "typedb-protocol/cluster/cluster_server_pb";
+import {
+    ClusterUser as ClusterUserProto,
+    ClusterUserManager as ClusterUserManagerProto
+} from "typedb-protocol/cluster/cluster_user_pb";
+import {
+    Attribute as AttributeProto,
+    AttributeType as AttributeTypeProto,
+    ConceptManager as ConceptMgrProto,
+    ConceptValue as ConceptValueProto,
+    ConceptValue,
+    EntityType as EntityTypeProto,
+    Relation as RelationProto,
+    RelationType as RelationTypeProto,
+    RoleType as RoleTypeProto,
+    Thing as ThingProto,
+    ThingType as ThingTypeProto,
+    Type as TypeProto,
+    ValueType as ValueTypeProto
+} from "typedb-protocol/common/concept_pb";
+import {LogicManager as LogicProto, Rule as RuleProto} from "typedb-protocol/common/logic_pb";
+import {Options} from "typedb-protocol/common/options_pb";
+import {QueryManager as QueryProto} from "typedb-protocol/common/query_pb";
+import {Session as SessionProto} from "typedb-protocol/common/session_pb";
+import {Transaction as TransactionProto} from "typedb-protocol/common/transaction_pb";
+import {CoreDatabase, CoreDatabaseManager} from "typedb-protocol/core/core_database_pb";
 import * as uuid from "uuid";
-import { Label } from "../Label";
-import { Bytes } from "../util/Bytes";
+import {Label} from "../Label";
+import {Bytes} from "../util/Bytes";
+
 
 /* eslint no-inner-declarations: "off" */
 export namespace RequestBuilder {
@@ -95,7 +113,7 @@ export namespace RequestBuilder {
             export function passwordSetReq(name: string, password: string): ClusterUserManagerProto.PasswordSet.Req {
                 return new ClusterUserManagerProto.PasswordSet.Req().setUsername(name).setPassword(password);
             }
-            
+
             export function getReq(name: string): ClusterUserManagerProto.Get.Req {
                 return new ClusterUserManagerProto.Get.Req().setUsername(name);
             }
@@ -125,7 +143,6 @@ export namespace RequestBuilder {
 
         }
     }
-
 
     export namespace Session {
 
@@ -211,7 +228,6 @@ export namespace RequestBuilder {
         }
     }
 
-
     export namespace QueryManager {
 
         function queryManagerReq(queryReq: QueryProto.Req, options: Options) {
@@ -279,7 +295,6 @@ export namespace RequestBuilder {
         }
     }
 
-
     export namespace ConceptManager {
 
         function conceptManagerReq(req: ConceptMgrProto.Req): TransactionProto.Req {
@@ -298,7 +313,7 @@ export namespace RequestBuilder {
             );
         }
 
-        export function putAttributeTypeReq(label: string, valueType: AttributeTypeProto.ValueType) {
+        export function putAttributeTypeReq(label: string, valueType: ValueTypeProto) {
             return conceptManagerReq(new ConceptMgrProto.Req().setPutAttributeTypeReq(
                 new ConceptMgrProto.PutAttributeType.Req().setLabel(label).setValueType(valueType)
             ));
@@ -315,6 +330,30 @@ export namespace RequestBuilder {
                 new ConceptMgrProto.GetThing.Req().setIid(Bytes.hexStringToBytes(iid))
             ));
         }
+    }
+
+    export namespace Concept {
+
+        export function conceptValueBooleanProto(value: boolean): ConceptValue {
+            return new ConceptValue().setBoolean(value);
+        }
+
+        export function conceptValueLongProto(value: number): ConceptValueProto {
+            return new ConceptValue().setLong(value);
+        }
+
+        export function conceptValueDoubleProto(value: number): ConceptValueProto {
+            return new ConceptValue().setDouble(value);
+        }
+
+        export function conceptValueStringProto(value: string): ConceptValueProto {
+            return new ConceptValue().setString(value);
+        }
+
+        export function conceptValueDateTimeProto(value: Date): ConceptValueProto {
+            return new ConceptValue().setDateTime(value.getTime());
+        }
+
     }
 
     export namespace Type {
@@ -475,7 +514,7 @@ export namespace RequestBuilder {
                 ));
             }
 
-            export function getOwnsByTypeReq(label: Label, valueType: AttributeTypeProto.ValueType, annotations: TypeProto.Annotation[]) {
+            export function getOwnsByTypeReq(label: Label, valueType: ValueTypeProto, annotations: TypeProto.Annotation[]) {
                 return typeReq(newReqBuilder(label).setThingTypeGetOwnsReq(
                     new ThingTypeProto.GetOwns.Req().setAnnotationsList(annotations)
                         .setValueType(valueType)
@@ -488,7 +527,7 @@ export namespace RequestBuilder {
                 ));
             }
 
-            export function getOwnsExplicitByTypeReq(label: Label, valueType: AttributeTypeProto.ValueType, annotations: TypeProto.Annotation[]) {
+            export function getOwnsExplicitByTypeReq(label: Label, valueType: ValueTypeProto, annotations: TypeProto.Annotation[]) {
                 return typeReq(newReqBuilder(label).setThingTypeGetOwnsExplicitReq(
                     new ThingTypeProto.GetOwnsExplicit.Req().setAnnotationsList(annotations)
                         .setValueType(valueType)
@@ -610,13 +649,13 @@ export namespace RequestBuilder {
                 ));
             }
 
-            export function putReq(label: Label, value: AttributeProto.Value) {
+            export function putReq(label: Label, value: ConceptValueProto) {
                 return typeReq(newReqBuilder(label).setAttributeTypePutReq(
                     new AttributeTypeProto.Put.Req().setValue(value)
                 ));
             }
 
-            export function getReq(label: Label, value: AttributeProto.Value) {
+            export function getReq(label: Label, value: ConceptValueProto) {
                 return typeReq(newReqBuilder(label).setAttributeTypeGetReq(
                     new AttributeTypeProto.Get.Req().setValue(value)
                 ));
@@ -745,26 +784,6 @@ export namespace RequestBuilder {
                 return thingReq(new ThingProto.Req().setIid(Bytes.hexStringToBytes(iid)).setAttributeGetOwnersReq(
                     new AttributeProto.GetOwners.Req().setThingType(ownerType)
                 ));
-            }
-
-            export function attributeValueBooleanReq(value: boolean): AttributeProto.Value {
-                return new AttributeProto.Value().setBoolean(value);
-            }
-
-            export function attributeValueLongReq(value: number): AttributeProto.Value {
-                return new AttributeProto.Value().setLong(value);
-            }
-
-            export function attributeValueDoubleReq(value: number): AttributeProto.Value {
-                return new AttributeProto.Value().setDouble(value);
-            }
-
-            export function attributeValueStringReq(value: string): AttributeProto.Value {
-                return new AttributeProto.Value().setString(value);
-            }
-
-            export function attributeValueDateTimeReq(value: Date): AttributeProto.Value {
-                return new AttributeProto.Value().setDateTime(value.getTime());
             }
         }
     }

--- a/concept/ConceptImpl.ts
+++ b/concept/ConceptImpl.ts
@@ -34,6 +34,7 @@ import { TypeDBTransaction } from "../api/connection/TypeDBTransaction";
 import { ErrorMessage } from "../common/errors/ErrorMessage";
 import { TypeDBClientError } from "../common/errors/TypeDBClientError";
 import INVALID_CONCEPT_CASTING = ErrorMessage.Concept.INVALID_CONCEPT_CASTING;
+import {Value} from "../api/concept/value/Value";
 
 export abstract class ConceptImpl implements Concept {
 
@@ -85,6 +86,10 @@ export abstract class ConceptImpl implements Concept {
         return false;
     }
 
+    isValue(): boolean {
+        return false;
+    }
+
     asAttribute(): Attribute {
         throw new TypeDBClientError(INVALID_CONCEPT_CASTING.message(this.className, "Attribute"));
     }
@@ -103,6 +108,10 @@ export abstract class ConceptImpl implements Concept {
 
     asRelation(): Relation {
         throw new TypeDBClientError(INVALID_CONCEPT_CASTING.message(this.className, "Relation"));
+    }
+
+    asValue(): Value {
+        throw new TypeDBClientError(INVALID_CONCEPT_CASTING.message(this.className, "Value"));
     }
 
     asRelationType(): RelationType {

--- a/concept/ConceptManagerImpl.ts
+++ b/concept/ConceptManagerImpl.ts
@@ -30,6 +30,7 @@ import { ThingType } from "../api/concept/type/ThingType";
 import { TypeDBTransaction } from "../api/connection/TypeDBTransaction";
 import { RequestBuilder } from "../common/rpc/RequestBuilder";
 import { AttributeTypeImpl, EntityTypeImpl, RelationTypeImpl, ThingImpl, ThingTypeImpl, } from "../dependencies_internal";
+import {Concept} from "../api/concept/Concept";
 
 export class ConceptManagerImpl implements ConceptManager {
 
@@ -105,7 +106,7 @@ export class ConceptManagerImpl implements ConceptManager {
         return RelationTypeImpl.of(response.getPutRelationTypeRes().getRelationType());
     }
 
-    async putAttributeType(label: string, valueType: AttributeType.ValueType): Promise<AttributeType> {
+    async putAttributeType(label: string, valueType: Concept.ValueType): Promise<AttributeType> {
         const request = RequestBuilder.ConceptManager.putAttributeTypeReq(label, valueType.proto());
         const response = await this.execute(request);
         return AttributeTypeImpl.of(response.getPutAttributeTypeRes().getAttributeType());

--- a/concept/answer/ConceptMapGroupImpl.ts
+++ b/concept/answer/ConceptMapGroupImpl.ts
@@ -52,7 +52,7 @@ export namespace ConceptMapGroupImpl {
         let owner: Concept;
         if (mapGroupProto.getOwner().hasThing()) owner = ThingImpl.of(mapGroupProto.getOwner().getThing());
         else if (mapGroupProto.getOwner().hasType()) owner = TypeImpl.of(mapGroupProto.getOwner().getType());
-        else ValueImpl.of(mapGroupProto.getOwner().getValue());
+        else owner = ValueImpl.of(mapGroupProto.getOwner().getValue());
         return new ConceptMapGroupImpl(owner, mapGroupProto.getConceptMapsList()
             .map((conceptMapProto) => ConceptMapImpl.of(conceptMapProto)));
     }

--- a/concept/answer/ConceptMapGroupImpl.ts
+++ b/concept/answer/ConceptMapGroupImpl.ts
@@ -19,12 +19,13 @@
  * under the License.
  */
 
-import { ConceptMapGroup as MapGroupProto } from "typedb-protocol/common/answer_pb";
-import { ConceptMap } from "../../api/answer/ConceptMap";
-import { ConceptMapGroup } from "../../api/answer/ConceptMapGroup";
-import { Concept } from "../../api/concept/Concept";
-import { ThingImpl, TypeImpl } from "../../dependencies_internal";
-import { ConceptMapImpl } from "./ConceptMapImpl";
+import {ConceptMapGroup as MapGroupProto} from "typedb-protocol/common/answer_pb";
+import {ConceptMap} from "../../api/answer/ConceptMap";
+import {ConceptMapGroup} from "../../api/answer/ConceptMapGroup";
+import {Concept} from "../../api/concept/Concept";
+import {ThingImpl, TypeImpl} from "../../dependencies_internal";
+import {ConceptMapImpl} from "./ConceptMapImpl";
+import {ValueImpl} from "../value/ValueImpl";
 
 export class ConceptMapGroupImpl implements ConceptMapGroup {
 
@@ -50,7 +51,8 @@ export namespace ConceptMapGroupImpl {
     export function of(mapGroupProto: MapGroupProto): ConceptMapGroup {
         let owner: Concept;
         if (mapGroupProto.getOwner().hasThing()) owner = ThingImpl.of(mapGroupProto.getOwner().getThing());
-        else owner = TypeImpl.of(mapGroupProto.getOwner().getType());
+        else if (mapGroupProto.getOwner().hasType()) owner = TypeImpl.of(mapGroupProto.getOwner().getType());
+        else ValueImpl.of(mapGroupProto.getOwner().getValue());
         return new ConceptMapGroupImpl(owner, mapGroupProto.getConceptMapsList()
             .map((conceptMapProto) => ConceptMapImpl.of(conceptMapProto)));
     }

--- a/concept/answer/ConceptMapImpl.ts
+++ b/concept/answer/ConceptMapImpl.ts
@@ -76,7 +76,7 @@ export namespace ConceptMapImpl {
             let concept;
             if (protoConcept.hasThing()) concept = ThingImpl.of(protoConcept.getThing());
             else if (protoConcept.hasType()) concept = TypeImpl.of(protoConcept.getType());
-            else concept = ValueImpl.of(protoConcept.getType());
+            else concept = ValueImpl.of(protoConcept.getValue());
             variableMap.set(resLabel, concept);
         });
         const explainables = proto.hasExplainables() ? ofExplainables(proto.getExplainables()) : emptyExplainables();

--- a/concept/answer/ConceptMapImpl.ts
+++ b/concept/answer/ConceptMapImpl.ts
@@ -26,6 +26,7 @@ import { Concept } from "../../api/concept/Concept";
 import { ErrorMessage } from "../../common/errors/ErrorMessage";
 import { TypeDBClientError } from "../../common/errors/TypeDBClientError";
 import { ThingImpl, TypeImpl } from "../../dependencies_internal";
+import {ValueImpl} from "../value/ValueImpl";
 
 export class ConceptMapImpl implements ConceptMap {
 
@@ -74,7 +75,8 @@ export namespace ConceptMapImpl {
         proto.getMapMap().forEach((protoConcept: ConceptProto, resLabel: string) => {
             let concept;
             if (protoConcept.hasThing()) concept = ThingImpl.of(protoConcept.getThing());
-            else concept = TypeImpl.of(protoConcept.getType());
+            else if (protoConcept.hasType()) concept = TypeImpl.of(protoConcept.getType());
+            else concept = ValueImpl.of(protoConcept.getType());
             variableMap.set(resLabel, concept);
         });
         const explainables = proto.hasExplainables() ? ofExplainables(proto.getExplainables()) : emptyExplainables();

--- a/concept/answer/NumericGroupImpl.ts
+++ b/concept/answer/NumericGroupImpl.ts
@@ -19,12 +19,13 @@
  * under the License.
  */
 
-import { NumericGroup as NumericGroupProto } from "typedb-protocol/common/answer_pb";
-import { Numeric } from "../../api/answer/Numeric";
-import { NumericGroup } from "../../api/answer/NumericGroup";
-import { Concept } from "../../api/concept/Concept";
-import { ThingImpl, TypeImpl } from "../../dependencies_internal";
-import { NumericImpl } from "./NumericImpl";
+import {NumericGroup as NumericGroupProto} from "typedb-protocol/common/answer_pb";
+import {Numeric} from "../../api/answer/Numeric";
+import {NumericGroup} from "../../api/answer/NumericGroup";
+import {Concept} from "../../api/concept/Concept";
+import {ThingImpl, TypeImpl} from "../../dependencies_internal";
+import {NumericImpl} from "./NumericImpl";
+import {ValueImpl} from "../value/ValueImpl";
 
 export class NumericGroupImpl implements NumericGroup {
 
@@ -50,7 +51,8 @@ export namespace NumericGroupImpl {
     export function of(numericGroupProto: NumericGroupProto) {
         let concept: Concept;
         if (numericGroupProto.getOwner().hasThing()) concept = ThingImpl.of(numericGroupProto.getOwner().getThing());
-        else concept = TypeImpl.of(numericGroupProto.getOwner().getType());
+        else if (numericGroupProto.getOwner().hasType()) concept = TypeImpl.of(numericGroupProto.getOwner().getType());
+        else concept = ValueImpl.of(numericGroupProto.getOwner().getValue());
         return new NumericGroupImpl(concept, NumericImpl.of(numericGroupProto.getNumber()))
     }
 }

--- a/concept/thing/ThingImpl.ts
+++ b/concept/thing/ThingImpl.ts
@@ -59,7 +59,7 @@ export abstract class ThingImpl extends ConceptImpl implements Thing {
     abstract asRemote(transaction: TypeDBTransaction): Thing.Remote;
 
     equals(concept: Concept): boolean {
-        if (concept.isType()) return false;
+        if (!concept.isThing()) return false;
         else return concept.asThing().iid === this._iid;
     }
 

--- a/concept/type/AttributeTypeImpl.ts
+++ b/concept/type/AttributeTypeImpl.ts
@@ -21,9 +21,9 @@
 
 
 import {
-    Attribute as AttributeProto,
-    AttributeType as AttributeTypeProto,
-    Type as TypeProto
+    ConceptValue as ConceptValueProto,
+    Type as TypeProto,
+    ValueType as ValueTypeProto
 } from "typedb-protocol/common/concept_pb";
 import {Attribute} from "../../api/concept/thing/Attribute";
 import {AttributeType} from "../../api/concept/type/AttributeType";
@@ -35,6 +35,7 @@ import {Label} from "../../common/Label";
 import {RequestBuilder} from "../../common/rpc/RequestBuilder";
 import {Stream} from "../../common/util/Stream";
 import {AttributeImpl, ThingTypeImpl} from "../../dependencies_internal";
+import {Concept} from "../../api/concept/Concept";
 import Annotation = ThingType.Annotation;
 import BAD_VALUE_TYPE = ErrorMessage.Concept.BAD_VALUE_TYPE;
 import INVALID_CONCEPT_CASTING = ErrorMessage.Concept.INVALID_CONCEPT_CASTING;
@@ -53,8 +54,8 @@ export class AttributeTypeImpl extends ThingTypeImpl implements AttributeType {
         return new AttributeTypeImpl.Remote(transaction as TypeDBTransaction.Extended, this.label, this.root, this.abstract);
     }
 
-    get valueType(): AttributeType.ValueType {
-        return AttributeType.ValueType.OBJECT;
+    get valueType(): Concept.ValueType {
+        return Concept.ValueType.OBJECT;
     }
 
     isAttributeType(): boolean {
@@ -126,17 +127,17 @@ export namespace AttributeTypeImpl {
     export function of(attributeTypeProto: TypeProto): AttributeType {
         if (!attributeTypeProto) return null;
         switch (attributeTypeProto.getValueType()) {
-            case AttributeTypeProto.ValueType.BOOLEAN:
+            case ValueTypeProto.BOOLEAN:
                 return new AttributeTypeImpl.Boolean(attributeTypeProto.getLabel(), attributeTypeProto.getIsRoot(), attributeTypeProto.getIsAbstract());
-            case AttributeTypeProto.ValueType.LONG:
+            case ValueTypeProto.LONG:
                 return new AttributeTypeImpl.Long(attributeTypeProto.getLabel(), attributeTypeProto.getIsRoot(), attributeTypeProto.getIsAbstract());
-            case AttributeTypeProto.ValueType.DOUBLE:
+            case ValueTypeProto.DOUBLE:
                 return new AttributeTypeImpl.Double(attributeTypeProto.getLabel(), attributeTypeProto.getIsRoot(), attributeTypeProto.getIsAbstract());
-            case AttributeTypeProto.ValueType.STRING:
+            case ValueTypeProto.STRING:
                 return new AttributeTypeImpl.String(attributeTypeProto.getLabel(), attributeTypeProto.getIsRoot(), attributeTypeProto.getIsAbstract());
-            case AttributeTypeProto.ValueType.DATETIME:
+            case ValueTypeProto.DATETIME:
                 return new AttributeTypeImpl.DateTime(attributeTypeProto.getLabel(), attributeTypeProto.getIsRoot(), attributeTypeProto.getIsAbstract());
-            case AttributeTypeProto.ValueType.OBJECT:
+            case ValueTypeProto.OBJECT:
                 return new AttributeTypeImpl(attributeTypeProto.getLabel(), attributeTypeProto.getIsRoot(), attributeTypeProto.getIsAbstract());
             default:
                 throw new TypeDBClientError(BAD_VALUE_TYPE.message(attributeTypeProto.getValueType()));
@@ -157,8 +158,8 @@ export namespace AttributeTypeImpl {
             return new AttributeTypeImpl.Remote(transaction as TypeDBTransaction.Extended, this.label, this.root, this.abstract);
         }
 
-        get valueType(): AttributeType.ValueType {
-            return AttributeType.ValueType.OBJECT;
+        get valueType(): Concept.ValueType {
+            return Concept.ValueType.OBJECT;
         }
 
         isAttributeType(): boolean {
@@ -256,8 +257,8 @@ export namespace AttributeTypeImpl {
                 .map((thingTypeProto) => ThingTypeImpl.of(thingTypeProto));
         }
 
-        protected getImpl(valueProto: AttributeProto.Value): Promise<Attribute> {
-            const request = RequestBuilder.Type.AttributeType.getReq(this.label, valueProto);
+        protected getImpl(conceptValueProto: ConceptValueProto): Promise<Attribute> {
+            const request = RequestBuilder.Type.AttributeType.getReq(this.label, conceptValueProto);
             return this.execute(request)
                 .then((attrProto) => AttributeImpl.of(attrProto.getAttributeTypeGetRes().getAttribute()));
         }
@@ -277,8 +278,8 @@ export namespace AttributeTypeImpl {
             return new AttributeTypeImpl.Boolean.Remote(transaction as TypeDBTransaction.Extended, this.label, this.root, this.abstract);
         }
 
-        get valueType(): AttributeType.ValueType {
-            return AttributeType.ValueType.BOOLEAN;
+        get valueType(): Concept.ValueType {
+            return Concept.ValueType.BOOLEAN;
         }
 
         isBoolean(): boolean {
@@ -306,8 +307,8 @@ export namespace AttributeTypeImpl {
                 return new AttributeTypeImpl.Boolean.Remote(transaction as TypeDBTransaction.Extended, this.label, this.root, this.abstract);
             }
 
-            get valueType(): AttributeType.ValueType {
-                return AttributeType.ValueType.BOOLEAN;
+            get valueType(): Concept.ValueType {
+                return Concept.ValueType.BOOLEAN;
             }
 
             isBoolean(): boolean {
@@ -319,7 +320,7 @@ export namespace AttributeTypeImpl {
             }
 
             async get(value: boolean): Promise<Attribute.Boolean> {
-                return await (super.getImpl(RequestBuilder.Thing.Attribute.attributeValueBooleanReq(value)) as Promise<Attribute.Boolean>);
+                return await (super.getImpl(RequestBuilder.Concept.conceptValueBooleanProto(value)) as Promise<Attribute.Boolean>);
             }
 
             getInstances(): Stream<Attribute.Boolean> {
@@ -331,7 +332,7 @@ export namespace AttributeTypeImpl {
             }
 
             async put(value: boolean): Promise<Attribute.Boolean> {
-                const request = RequestBuilder.Type.AttributeType.putReq(this.label, RequestBuilder.Thing.Attribute.attributeValueBooleanReq(value));
+                const request = RequestBuilder.Type.AttributeType.putReq(this.label, RequestBuilder.Concept.conceptValueBooleanProto(value));
                 return await (this.execute(request).then((res) => AttributeImpl.of(res.getAttributeTypePutRes().getAttribute())) as Promise<Attribute.Boolean>);
             }
         }
@@ -351,8 +352,8 @@ export namespace AttributeTypeImpl {
             return new AttributeTypeImpl.Long.Remote(transaction as TypeDBTransaction.Extended, this.label, this.root, this.abstract);
         }
 
-        get valueType(): AttributeType.ValueType {
-            return AttributeType.ValueType.LONG;
+        get valueType(): Concept.ValueType {
+            return Concept.ValueType.LONG;
         }
 
         isLong(): boolean {
@@ -380,8 +381,8 @@ export namespace AttributeTypeImpl {
                 return new AttributeTypeImpl.Long.Remote(transaction as TypeDBTransaction.Extended, this.label, this.root, this.abstract);
             }
 
-            get valueType(): AttributeType.ValueType {
-                return AttributeType.ValueType.LONG;
+            get valueType(): Concept.ValueType {
+                return Concept.ValueType.LONG;
             }
 
             isLong(): boolean {
@@ -401,11 +402,11 @@ export namespace AttributeTypeImpl {
             }
 
             async get(value: number): Promise<Attribute.Long> {
-                return await (super.getImpl(RequestBuilder.Thing.Attribute.attributeValueLongReq(value)) as Promise<Attribute.Long>);
+                return await (super.getImpl(RequestBuilder.Concept.conceptValueLongProto(value)) as Promise<Attribute.Long>);
             }
 
             async put(value: number): Promise<Attribute.Long> {
-                const request = RequestBuilder.Type.AttributeType.putReq(this.label, RequestBuilder.Thing.Attribute.attributeValueLongReq(value));
+                const request = RequestBuilder.Type.AttributeType.putReq(this.label, RequestBuilder.Concept.conceptValueLongProto(value));
                 return await (this.execute(request).then((res) => AttributeImpl.of(res.getAttributeTypePutRes().getAttribute())) as Promise<Attribute.Long>);
             }
         }
@@ -425,8 +426,8 @@ export namespace AttributeTypeImpl {
             return new AttributeTypeImpl.Double.Remote(transaction as TypeDBTransaction.Extended, this.label, this.root, this.abstract);
         }
 
-        get valueType(): AttributeType.ValueType {
-            return AttributeType.ValueType.DOUBLE;
+        get valueType(): Concept.ValueType {
+            return Concept.ValueType.DOUBLE;
         }
 
         isDouble(): boolean {
@@ -454,8 +455,8 @@ export namespace AttributeTypeImpl {
                 return new AttributeTypeImpl.Double.Remote(transaction as TypeDBTransaction.Extended, this.label, this.root, this.abstract);
             }
 
-            get valueType(): AttributeType.ValueType {
-                return AttributeType.ValueType.DOUBLE;
+            get valueType(): Concept.ValueType {
+                return Concept.ValueType.DOUBLE;
             }
 
             isDouble(): boolean {
@@ -475,11 +476,11 @@ export namespace AttributeTypeImpl {
             }
 
             async get(value: number): Promise<Attribute.Double> {
-                return await (super.getImpl(RequestBuilder.Thing.Attribute.attributeValueDoubleReq(value)) as Promise<Attribute.Double>);
+                return await (super.getImpl(RequestBuilder.Concept.conceptValueDoubleProto(value)) as Promise<Attribute.Double>);
             }
 
             async put(value: number): Promise<Attribute.Double> {
-                const request = RequestBuilder.Type.AttributeType.putReq(this.label, RequestBuilder.Thing.Attribute.attributeValueDoubleReq(value));
+                const request = RequestBuilder.Type.AttributeType.putReq(this.label, RequestBuilder.Concept.conceptValueDoubleProto(value));
                 return await (this.execute(request).then((res) => AttributeImpl.of(res.getAttributeTypePutRes().getAttribute())) as Promise<Attribute.Double>);
             }
         }
@@ -499,8 +500,8 @@ export namespace AttributeTypeImpl {
             return new AttributeTypeImpl.String.Remote(transaction as TypeDBTransaction.Extended, this.label, this.root, this.abstract)
         }
 
-        get valueType(): AttributeType.ValueType {
-            return AttributeType.ValueType.STRING;
+        get valueType(): Concept.ValueType {
+            return Concept.ValueType.STRING;
         }
 
         isString(): boolean {
@@ -528,8 +529,8 @@ export namespace AttributeTypeImpl {
                 return new AttributeTypeImpl.String.Remote(transaction as TypeDBTransaction.Extended, this.label, this.root, this.abstract)
             }
 
-            get valueType(): AttributeType.ValueType {
-                return AttributeType.ValueType.STRING;
+            get valueType(): Concept.ValueType {
+                return Concept.ValueType.STRING;
             }
 
             isString(): boolean {
@@ -549,11 +550,11 @@ export namespace AttributeTypeImpl {
             }
 
             async get(value: string): Promise<Attribute.String> {
-                return await (super.getImpl(RequestBuilder.Thing.Attribute.attributeValueStringReq(value)) as Promise<Attribute.String>);
+                return await (super.getImpl(RequestBuilder.Concept.conceptValueStringProto(value)) as Promise<Attribute.String>);
             }
 
             async put(value: string): Promise<Attribute.String> {
-                const request = RequestBuilder.Type.AttributeType.putReq(this.label, RequestBuilder.Thing.Attribute.attributeValueStringReq(value));
+                const request = RequestBuilder.Type.AttributeType.putReq(this.label, RequestBuilder.Concept.conceptValueStringProto(value));
                 return await (this.execute(request).then((res) => AttributeImpl.of(res.getAttributeTypePutRes().getAttribute())) as Promise<Attribute.String>);
             }
 
@@ -583,8 +584,8 @@ export namespace AttributeTypeImpl {
             return new AttributeTypeImpl.DateTime.Remote(transaction as TypeDBTransaction.Extended, this.label, this.root, this.abstract);
         }
 
-        get valueType(): AttributeType.ValueType {
-            return AttributeType.ValueType.DATETIME;
+        get valueType(): Concept.ValueType {
+            return Concept.ValueType.DATETIME;
         }
 
         isDateTime(): boolean {
@@ -612,8 +613,8 @@ export namespace AttributeTypeImpl {
                 return new AttributeTypeImpl.DateTime.Remote(transaction as TypeDBTransaction.Extended, this.label, this.root, this.abstract);
             }
 
-            get valueType(): AttributeType.ValueType {
-                return AttributeType.ValueType.DATETIME;
+            get valueType(): Concept.ValueType {
+                return Concept.ValueType.DATETIME;
             }
 
             isDateTime(): boolean {
@@ -633,11 +634,11 @@ export namespace AttributeTypeImpl {
             }
 
             async get(value: Date): Promise<Attribute.DateTime> {
-                return await (super.getImpl(RequestBuilder.Thing.Attribute.attributeValueDateTimeReq(value)) as Promise<Attribute.DateTime>);
+                return await (super.getImpl(RequestBuilder.Concept.conceptValueDateTimeProto(value)) as Promise<Attribute.DateTime>);
             }
 
             async put(value: Date): Promise<Attribute.DateTime> {
-                const request = RequestBuilder.Type.AttributeType.putReq(this.label, RequestBuilder.Thing.Attribute.attributeValueDateTimeReq(value));
+                const request = RequestBuilder.Type.AttributeType.putReq(this.label, RequestBuilder.Concept.conceptValueDateTimeProto(value));
                 return await (this.execute(request).then((res) => AttributeImpl.of(res.getAttributeTypePutRes().getAttribute())) as Promise<Attribute.DateTime>);
             }
         }

--- a/concept/type/ThingTypeImpl.ts
+++ b/concept/type/ThingTypeImpl.ts
@@ -40,6 +40,7 @@ import {
 } from "../../dependencies_internal";
 import BAD_ENCODING = ErrorMessage.Concept.BAD_ENCODING;
 import Annotation = ThingType.Annotation;
+import {Concept} from "../../api/concept/Concept";
 
 export class ThingTypeImpl extends TypeImpl implements ThingType {
 
@@ -125,10 +126,10 @@ export namespace ThingTypeImpl {
         }
 
         getOwns(): Stream<AttributeType>;
-        getOwns(valueType: AttributeType.ValueType): Stream<AttributeType>;
+        getOwns(valueType: Concept.ValueType): Stream<AttributeType>;
         getOwns(annotations: Annotation[]): Stream<AttributeType>;
-        getOwns(valueType: AttributeType.ValueType, annotations: Annotation[]): Stream<AttributeType>;
-        getOwns(valueTypeOrAnnotationsOnly?: AttributeType.ValueType | Annotation[], annotations?: Annotation[]): Stream<AttributeType> {
+        getOwns(valueType: Concept.ValueType, annotations: Annotation[]): Stream<AttributeType>;
+        getOwns(valueTypeOrAnnotationsOnly?: Concept.ValueType | Annotation[], annotations?: Annotation[]): Stream<AttributeType> {
             let request;
             if (!valueTypeOrAnnotationsOnly) {
                 request = RequestBuilder.Type.ThingType.getOwnsReq(this.label, []);
@@ -138,11 +139,11 @@ export namespace ThingTypeImpl {
                 );
             } else if (!annotations) {
                 request = RequestBuilder.Type.ThingType.getOwnsByTypeReq(
-                    this.label, (valueTypeOrAnnotationsOnly as AttributeType.ValueType).proto(), []
+                    this.label, (valueTypeOrAnnotationsOnly as Concept.ValueType).proto(), []
                 );
             } else {
                 request = RequestBuilder.Type.ThingType.getOwnsByTypeReq(
-                    this.label, (valueTypeOrAnnotationsOnly as AttributeType.ValueType).proto(),
+                    this.label, (valueTypeOrAnnotationsOnly as Concept.ValueType).proto(),
                     annotations.map(a => ThingType.Annotation.proto(a))
                 );
             }
@@ -153,10 +154,10 @@ export namespace ThingTypeImpl {
 
 
         getOwnsExplicit(): Stream<AttributeType>;
-        getOwnsExplicit(valueType: AttributeType.ValueType): Stream<AttributeType>;
+        getOwnsExplicit(valueType: Concept.ValueType): Stream<AttributeType>;
         getOwnsExplicit(annotations: Annotation[]): Stream<AttributeType>;
-        getOwnsExplicit(valueType: AttributeType.ValueType, annotations: Annotation[]): Stream<AttributeType>;
-        getOwnsExplicit(valueTypeOrAnnotationsOnly?: AttributeType.ValueType | Annotation[], annotations?: Annotation[]): Stream<AttributeType> {
+        getOwnsExplicit(valueType: Concept.ValueType, annotations: Annotation[]): Stream<AttributeType>;
+        getOwnsExplicit(valueTypeOrAnnotationsOnly?: Concept.ValueType | Annotation[], annotations?: Annotation[]): Stream<AttributeType> {
             let request;
             if (!valueTypeOrAnnotationsOnly) {
                 request = RequestBuilder.Type.ThingType.getOwnsExplicitReq(this.label, []);
@@ -166,11 +167,11 @@ export namespace ThingTypeImpl {
                 );
             } else if (!annotations) {
                 request = RequestBuilder.Type.ThingType.getOwnsExplicitByTypeReq(
-                    this.label, (valueTypeOrAnnotationsOnly as AttributeType.ValueType).proto(), []
+                    this.label, (valueTypeOrAnnotationsOnly as Concept.ValueType).proto(), []
                 );
             } else {
                 request = RequestBuilder.Type.ThingType.getOwnsExplicitByTypeReq(
-                    this.label, (valueTypeOrAnnotationsOnly as AttributeType.ValueType).proto(),
+                    this.label, (valueTypeOrAnnotationsOnly as Concept.ValueType).proto(),
                     annotations.map(a => ThingType.Annotation.proto(a))
                 );
             }

--- a/concept/value/ValueImpl.ts
+++ b/concept/value/ValueImpl.ts
@@ -1,0 +1,265 @@
+/*
+ * Copyright (C) 2022 Vaticle
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {Value} from "../../api/concept/value/Value";
+import {ConceptImpl} from "../ConceptImpl";
+import {Concept} from "../../api/concept/Concept";
+import {TypeDBTransaction} from "../../api/connection/TypeDBTransaction";
+import {TypeDBClientError} from "../../common/errors/TypeDBClientError";
+import {ErrorMessage} from "../../common/errors/ErrorMessage";
+import {Value as ValueProto, ValueType as ValueTypeProto} from "typedb-protocol/common/concept_pb";
+import ValueType = Concept.ValueType;
+import VALUE_HAS_NO_REMOTE = ErrorMessage.Concept.VALUE_HAS_NO_REMOTE;
+import INVALID_CONCEPT_CASTING = ErrorMessage.Concept.INVALID_CONCEPT_CASTING;
+
+import BAD_VALUE_TYPE = ErrorMessage.Concept.BAD_VALUE_TYPE;
+
+export abstract class ValueImpl extends ConceptImpl implements Value {
+
+    private readonly _valueType: ValueType;
+
+    protected constructor(type: ValueType) {
+        super();
+        this._valueType = type;
+    }
+
+    get valueType(): ValueType {
+        return this._valueType;
+    }
+
+    abstract get value(): boolean | string | number | Date;
+
+    asRemote(transaction: TypeDBTransaction): Concept.Remote {
+        throw new TypeDBClientError(VALUE_HAS_NO_REMOTE);
+    }
+
+    isValue(): boolean {
+        return true
+    }
+
+    asValue(): Value {
+        return this;
+    }
+
+    equals(concept: Concept): boolean {
+        if (!concept.isValue()) return false;
+        else {
+            return this.valueType == concept.asValue().valueType && this.value == concept.asValue().value;
+        }
+    }
+
+    toJSONRecord(): Record<string, boolean | string | number> {
+        let value;
+        if (this.value instanceof Date) value = this.value.toISOString().slice(0, -1);
+        else value = this.value;
+        return {
+            value_type: this.valueType.name(),
+            value: value
+        };
+    }
+
+    isBoolean(): boolean {
+        return false;
+    }
+
+    isDateTime(): boolean {
+        return false;
+    }
+
+    isDouble(): boolean {
+        return false;
+    }
+
+    isLong(): boolean {
+        return false;
+    }
+
+    isString(): boolean {
+        return false;
+    }
+
+    asBoolean(): Value.Boolean {
+        throw new TypeDBClientError(INVALID_CONCEPT_CASTING.message(this.className, "Value.Boolean"));
+    }
+
+    asLong(): Value.Long {
+        throw new TypeDBClientError(INVALID_CONCEPT_CASTING.message(this.className, "Value.Long"));
+    }
+
+    asDouble(): Value.Double {
+        throw new TypeDBClientError(INVALID_CONCEPT_CASTING.message(this.className, "Value.Double"));
+    }
+
+    asString(): Value.String {
+        throw new TypeDBClientError(INVALID_CONCEPT_CASTING.message(this.className, "Value.String"));
+    }
+
+    asDateTime(): Value.DateTime {
+        throw new TypeDBClientError(INVALID_CONCEPT_CASTING.message(this.className, "Value.DateTime"));
+    }
+}
+
+export namespace ValueImpl {
+
+    export function of(valueProto: ValueProto): Value {
+        if (!valueProto) return null;
+        switch (valueProto.getValuetype()) {
+            case ValueTypeProto.BOOLEAN:
+                return new ValueImpl.Boolean(valueProto.getValue().getBoolean());
+            case ValueTypeProto.LONG:
+                return new ValueImpl.Long(valueProto.getValue().getLong());
+            case ValueTypeProto.DOUBLE:
+                return new ValueImpl.Double(valueProto.getValue().getDouble());
+            case ValueTypeProto.STRING:
+                return new ValueImpl.String(valueProto.getValue().getString());
+            case ValueTypeProto.DATETIME:
+                return new ValueImpl.DateTime(new Date(valueProto.getValue().getDateTime()));
+            default:
+                throw new TypeDBClientError(BAD_VALUE_TYPE.message(valueProto.getValuetype()));
+        }
+    }
+
+    export class Boolean extends ValueImpl implements Value.Boolean {
+        readonly _value: boolean;
+
+        constructor(value: boolean) {
+            super(ValueType.BOOLEAN);
+            this._value = value;
+        }
+
+        get value(): boolean {
+            return this._value;
+        }
+
+        isBoolean(): boolean {
+            return true;
+        }
+
+        asBoolean(): Value.Boolean {
+            return this;
+        }
+
+        protected get className(): string {
+            return "Value.Boolean";
+        }
+    }
+
+    export class Long extends ValueImpl implements Value.Long {
+        readonly _value: number;
+
+        constructor(value: number) {
+            super(ValueType.LONG);
+            this._value = value;
+        }
+
+        get value(): number {
+            return this._value;
+        }
+
+        isLong(): boolean {
+            return true;
+        }
+
+        asLong(): Value.Long {
+            return this;
+        }
+
+        protected get className(): string {
+            return "Value.Long";
+        }
+    }
+
+    export class Double extends ValueImpl implements Value.Double {
+        readonly _value: number;
+
+        constructor(value: number) {
+            super(ValueType.DOUBLE);
+            this._value = value;
+        }
+
+        get value(): number {
+            return this._value;
+        }
+
+        isDouble(): boolean {
+            return true;
+        }
+
+        asDouble(): Value.Double {
+            return this;
+        }
+
+        protected get className(): string {
+            return "Value.Double";
+        }
+    }
+
+    export class String extends ValueImpl implements Value.String {
+        readonly _value: string;
+
+        constructor(value: string) {
+            super(ValueType.STRING);
+            this._value = value;
+        }
+
+        get value(): string {
+            return this._value;
+        }
+
+        isString(): boolean {
+            return true;
+        }
+
+        asString(): Value.String {
+            return this;
+        }
+
+        protected get className(): string {
+            return "Value.String";
+        }
+    }
+
+    export class DateTime extends ValueImpl implements Value.DateTime {
+        readonly _value: Date;
+
+        constructor(value: Date) {
+            super(ValueType.DOUBLE);
+            this._value = value;
+        }
+
+        get value(): Date {
+            return this._value;
+        }
+
+        isDateTime(): boolean {
+            return true;
+        }
+
+        asDateTime(): Value.DateTime {
+            return this;
+        }
+
+        protected get className(): string {
+            return "Value.DateTime";
+        }
+    }
+
+}

--- a/concept/value/ValueImpl.ts
+++ b/concept/value/ValueImpl.ts
@@ -121,7 +121,7 @@ export namespace ValueImpl {
 
     export function of(valueProto: ValueProto): Value {
         if (!valueProto) return null;
-        switch (valueProto.getValuetype()) {
+        switch (valueProto.getValueType()) {
             case ValueTypeProto.BOOLEAN:
                 return new ValueImpl.Boolean(valueProto.getValue().getBoolean());
             case ValueTypeProto.LONG:
@@ -133,7 +133,7 @@ export namespace ValueImpl {
             case ValueTypeProto.DATETIME:
                 return new ValueImpl.DateTime(new Date(valueProto.getValue().getDateTime()));
             default:
-                throw new TypeDBClientError(BAD_VALUE_TYPE.message(valueProto.getValuetype()));
+                throw new TypeDBClientError(BAD_VALUE_TYPE.message(valueProto.getValueType()));
         }
     }
 

--- a/concept/value/ValueImpl.ts
+++ b/concept/value/ValueImpl.ts
@@ -241,7 +241,7 @@ export namespace ValueImpl {
         readonly _value: Date;
 
         constructor(value: Date) {
-            super(ValueType.DOUBLE);
+            super(ValueType.DATETIME);
             this._value = value;
         }
 

--- a/dependencies/vaticle/artifacts.bzl
+++ b/dependencies/vaticle/artifacts.bzl
@@ -39,5 +39,5 @@ def vaticle_typedb_cluster_artifacts():
         artifact_name = "typedb-cluster-all-{platform}-{version}.{ext}",
         tag_source = deployment_private["artifact.release"],
         commit_source = deployment_private["artifact.snapshot"],
-        commit = "9b70d31b54ed0162ce5df6ac4ab6180229bd7cb9",
+        commit = "8044753056dd20b8e6bec6f62036eb0003d4ba06",
     )

--- a/dependencies/vaticle/artifacts.bzl
+++ b/dependencies/vaticle/artifacts.bzl
@@ -29,7 +29,7 @@ def vaticle_typedb_artifacts():
         artifact_name = "typedb-server-{platform}-{version}.{ext}",
         tag_source = deployment["artifact.release"],
         commit_source = deployment["artifact.snapshot"],
-        commit = "0f43f6654dff206d168711d90785d12df4c98b5e",
+        commit = "816ef97845a9577c2236db69dd94548b5869c083",
     )
 
 def vaticle_typedb_cluster_artifacts():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -40,5 +40,5 @@ def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
         remote = "https://github.com/krishnangovindraj/typedb-behaviour",
-        commit = "19bf32fc8353f876b1a97d6467e26fbc55f99fab" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        commit = "709d5739148e301ef59db93ac0cfa0b24c6cbe1d" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -39,6 +39,6 @@ def vaticle_typedb_common():
 def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
-        remote = "https://github.com/krishnangovindraj/typedb-behaviour",
-        commit = "709d5739148e301ef59db93ac0cfa0b24c6cbe1d" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        remote = "https://github.com/vaticle/typedb-behaviour",
+        commit = "767bf98fef7383addf42a1ae6e97a44874bb4f0b" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -25,7 +25,7 @@ def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
         remote = "https://github.com/vaticle/dependencies",
-        commit = "e0446ffa70cacca89cb1faa2cd6f299c3784d845", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        commit = "385716283e1e64245c3679a06054e271a0608ac1", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 #TODO: MOVE NATIVE_TYPEDB_ARTIFACT INTO DEPENDENCIES, THEN REMOVE THIS DEPENDENCY
@@ -33,12 +33,12 @@ def vaticle_typedb_common():
     git_repository(
         name = "vaticle_typedb_common",
         remote = "https://github.com/vaticle/typedb-common",
-        tag = "2.17.0" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
+        commit = "9372dfb227d54c6eb631eed02e67f250e55e657e" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
     )
 
 def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
-        remote = "https://github.com/vaticle/typedb-behaviour",
-        commit = "aa675d9052046b1a4ffd45f444854d8735028702" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        remote = "https://github.com/krishnangovindraj/typedb-behaviour",
+        commit = "19bf32fc8353f876b1a97d6467e26fbc55f99fab" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )

--- a/index.ts
+++ b/index.ts
@@ -31,6 +31,8 @@ export * from "./api/concept/thing/Entity";
 export * from "./api/concept/thing/Relation";
 export * from "./api/concept/thing/Thing";
 
+export * from "./api/concept/value/Value";
+
 export * from "./api/concept/type/AttributeType";
 export * from "./api/concept/type/EntityType";
 export * from "./api/concept/type/RelationType";

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@grpc/grpc-js": "1.5.0",
     "google-protobuf": "3.19.3",
-    "typedb-protocol": "https://repo.vaticle.com/repository/npm-snapshot/typedb-protocol/-/typedb-protocol-0.0.0-de4f5b4d31c3ff06d62da47d2a57605c4e3d4b29.tgz",
+    "typedb-protocol": "https://repo.vaticle.com/repository/npm-snapshot/typedb-protocol/-/typedb-protocol-0.0.0-3b893745265d79a8e0ea737214a8d12daf2b75b5.tgz",
     "uuid": "8.3.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@grpc/grpc-js": "1.5.0",
     "google-protobuf": "3.19.3",
-    "typedb-protocol": "https://repo.vaticle.com/repository/npm-snapshot/typedb-protocol/-/typedb-protocol-0.0.0-3b893745265d79a8e0ea737214a8d12daf2b75b5.tgz",
+    "typedb-protocol": "https://repo.vaticle.com/repository/npm-snapshot/typedb-protocol/-/typedb-protocol-0.0.0-5c073e625770e812e4807419392d7f7261a553fb.tgz",
     "uuid": "8.3.2"
   },
   "devDependencies": {

--- a/test/behaviour/concept/thing/attribute/AttributeSteps.ts
+++ b/test/behaviour/concept/thing/attribute/AttributeSteps.ts
@@ -19,13 +19,13 @@
  * under the License.
  */
 
-import { When } from "@cucumber/cucumber";
-import { Attribute, AttributeType } from "../../../../../dist";
-import { tx } from "../../../connection/ConnectionStepsBase";
-import { assertThrows } from "../../../util/Util";
-import { get, put } from "../ThingSteps";
+import {When} from "@cucumber/cucumber";
+import {Concept} from "../../../../../dist";
+import {tx} from "../../../connection/ConnectionStepsBase";
+import {assertThrows} from "../../../util/Util";
+import {get, put} from "../ThingSteps";
 import assert = require("assert");
-import ValueType = AttributeType.ValueType;
+import ValueType = Concept.ValueType;
 
 When("attribute\\({type_label}) get instances contain: {var}", async (typeLabel: string, var0: string) => {
     assert(await (await tx().concepts.getAttributeType(typeLabel)).asRemote(tx()).getInstances().some(x => x.equals(get(var0))));

--- a/test/behaviour/concept/type/attributetype/AttributeTypeSteps.ts
+++ b/test/behaviour/concept/type/attributetype/AttributeTypeSteps.ts
@@ -22,10 +22,10 @@
 import {Then, When} from "@cucumber/cucumber";
 import DataTable from "@cucumber/cucumber/lib/models/data_table";
 import assert, {equal} from "assert";
-import {AttributeType, ErrorMessage, ThingType, TypeDBClientError} from "../../../../../dist";
+import {Concept, ErrorMessage, ThingType, TypeDBClientError} from "../../../../../dist";
 import {parseList} from "../../../config/Parameters";
 import {tx} from "../../../connection/ConnectionStepsBase";
-import ValueType = AttributeType.ValueType;
+import ValueType = Concept.ValueType;
 import Annotation = ThingType.Annotation;
 
 When("put attribute type: {type_label}, with value type: {value_type}", async (typeLabel: string, valueType: ValueType) => {

--- a/test/behaviour/config/Parameters.ts
+++ b/test/behaviour/config/Parameters.ts
@@ -22,7 +22,7 @@
 import {defineParameterType} from "@cucumber/cucumber";
 import DataTable from "@cucumber/cucumber/lib/models/data_table";
 import {TransactionType} from "../../../dist/api/connection/TypeDBTransaction";
-import {AttributeType, ThingType} from "../../../dist";
+import {Concept, ThingType} from "../../../dist";
 import Annotation = ThingType.Annotation;
 
 export function parseBool(value: string): boolean {
@@ -111,15 +111,15 @@ defineParameterType({
     transformer: s => {
         switch (s) {
             case "long":
-                return AttributeType.ValueType.LONG
+                return Concept.ValueType.LONG
             case "double":
-                return AttributeType.ValueType.DOUBLE
+                return Concept.ValueType.DOUBLE
             case "string":
-                return AttributeType.ValueType.STRING
+                return Concept.ValueType.STRING
             case "boolean":
-                return AttributeType.ValueType.BOOLEAN
+                return Concept.ValueType.BOOLEAN
             case "datetime":
-                return AttributeType.ValueType.DATETIME
+                return Concept.ValueType.DATETIME
             default:
                 throw "Unrecognised value type in step definition"
         }

--- a/test/behaviour/typeql/TypeQLSteps.ts
+++ b/test/behaviour/typeql/TypeQLSteps.ts
@@ -132,7 +132,6 @@ When("get answer of typeql match aggregate", async (query: string) => {
 When("get answers of typeql match group", async (query: string) => {
     clearAnswers();
     answerGroups = await tx().query.matchGroup(query).collect();
-    console.log("Answer groups: ", answerGroups);
 });
 
 When("typeql match group; throws exception", async (query: string) => {
@@ -142,7 +141,6 @@ When("typeql match group; throws exception", async (query: string) => {
 When("get answers of typeql match group aggregate", async (query: string) => {
     clearAnswers();
     numericAnswerGroups = await tx().query.matchGroupAggregate(query).collect();
-    console.log("Answer groups: ", numericAnswerGroups);
 });
 
 When("typeql match aggregate; throws exception", async (query: string) => {

--- a/test/behaviour/typeql/TypeQLSteps.ts
+++ b/test/behaviour/typeql/TypeQLSteps.ts
@@ -289,8 +289,10 @@ function parseConceptIdentifier(value: string): ConceptMatcher {
             return new TypeLabelMatcher(identifierBody);
         case "key":
             return new ThingKeyMatcher(identifierBody);
-        case "value":
+        case "attr":
             return new AttributeValueMatcher(identifierBody);
+        case "value":
+            return new ValueMatcher(identifierBody);
         default:
             throw new Error(`Failed to parse concept identifier: ${value}`);
     }

--- a/test/behaviour/typeql/TypeQLSteps.ts
+++ b/test/behaviour/typeql/TypeQLSteps.ts
@@ -22,13 +22,12 @@
 import {Then, When} from "@cucumber/cucumber";
 import DataTable from "@cucumber/cucumber/lib/models/data_table";
 import {fail} from "assert";
-import {Attribute, Concept, ConceptMap, ConceptMapGroup, Numeric, NumericGroup, ThingType} from "../../../dist";
+import {Attribute, Concept, ConceptMap, ConceptMapGroup, Numeric, NumericGroup, ThingType, Value} from "../../../dist";
 import {parseBool} from "../config/Parameters";
 import {tx} from "../connection/ConnectionStepsBase";
 import {assertThrows, assertThrowsWithMessage, splitString} from "../util/Util";
 import assert = require("assert");
 import Annotation = ThingType.Annotation;
-import {Value} from "../../../api/concept/value/Value";
 
 export let answers: ConceptMap[] = [];
 let numericAnswer: Numeric;
@@ -278,7 +277,7 @@ class ValueMatcher implements ConceptMatcher {
     async matches(concept: Concept): Promise<boolean> {
         if (!concept.isValue()) return false;
         const value = concept.asValue();
-        if (this.valueType !== value.valueType) return false;
+        if (this.valueType !== value.valueType.name()) return false;
         return this.check(value);
     }
 }

--- a/test/behaviour/typeql/TypeQLSteps.ts
+++ b/test/behaviour/typeql/TypeQLSteps.ts
@@ -132,6 +132,7 @@ When("get answer of typeql match aggregate", async (query: string) => {
 When("get answers of typeql match group", async (query: string) => {
     clearAnswers();
     answerGroups = await tx().query.matchGroup(query).collect();
+    console.log("Answer groups: ", answerGroups);
 });
 
 When("typeql match group; throws exception", async (query: string) => {
@@ -141,6 +142,7 @@ When("typeql match group; throws exception", async (query: string) => {
 When("get answers of typeql match group aggregate", async (query: string) => {
     clearAnswers();
     numericAnswerGroups = await tx().query.matchGroupAggregate(query).collect();
+    console.log("Answer groups: ", numericAnswerGroups);
 });
 
 When("typeql match aggregate; throws exception", async (query: string) => {

--- a/test/behaviour/typeql/language/expression/BUILD
+++ b/test/behaviour/typeql/language/expression/BUILD
@@ -1,0 +1,41 @@
+#
+# Copyright (C) 2022 Vaticle
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+load("@vaticle_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
+load("//test/behaviour:rules.bzl", "typedb_behaviour_node_test")
+
+checkstyle_test(
+    name = "checkstyle",
+    include = glob(["*"]),
+    license_type = "apache-header",
+)
+
+typedb_behaviour_node_test(
+    name = "test",
+    features = ["@vaticle_typedb_behaviour//typeql/language:expression.feature"],
+    node_modules = "//:node_modules",
+    package_json = "//:package.json",
+    native_typedb_artifact_core = "//test:native-typedb-artifact",
+    native_typedb_artifact_cluster = "//test:native-typedb-cluster-artifact",
+    client = "//:client-nodejs-targz",
+    steps_core = "//test/behaviour:steps-core-targz",
+    steps_cluster = "//test/behaviour:steps-cluster-targz",
+)

--- a/test/behaviour/util/Util.ts
+++ b/test/behaviour/util/Util.ts
@@ -35,7 +35,7 @@ export async function assertThrowsWithMessage(testfunc: () => Promise<unknown>, 
     try {
         await testfunc();
     } catch (error) {
-        assert(error.toString().includes(message));
+        assert(error.toString().toLowerCase().includes(message.toLowerCase()));
         return
     }
     assert.fail();

--- a/test/integration/test-concept.js
+++ b/test/integration/test-concept.js
@@ -19,7 +19,7 @@
  * under the License.
  */
 
-const { TypeDB, SessionType, TransactionType, AttributeType, ThingType  } = require("../../dist");
+const { TypeDB, SessionType, TransactionType, Concept, ThingType  } = require("../../dist");
 const assert = require("assert");
 const Annotation = ThingType.Annotation;
 
@@ -78,7 +78,7 @@ async function run() {
 
     try {
         tx = await session.transaction(TransactionType.WRITE);
-        maneSize = await tx.concepts.putAttributeType("mane-size", AttributeType.ValueType.LONG);
+        maneSize = await tx.concepts.putAttributeType("mane-size", Concept.ValueType.LONG);
         await lion.asRemote(tx).setOwns(maneSize);
         await tx.commit();
         await tx.close();
@@ -203,11 +203,11 @@ async function run() {
     let email, workEmail, customer, age;
     try {
         tx = await session.transaction(TransactionType.WRITE);
-        email = await tx.concepts.putAttributeType("email", AttributeType.ValueType.STRING);
+        email = await tx.concepts.putAttributeType("email", Concept.ValueType.STRING);
         await email.asRemote(tx).setAbstract();
-        workEmail = await tx.concepts.putAttributeType("work-email", AttributeType.ValueType.STRING);
+        workEmail = await tx.concepts.putAttributeType("work-email", Concept.ValueType.STRING);
         await workEmail.asRemote(tx).setSupertype(email);
-        age = await tx.concepts.putAttributeType("age", AttributeType.ValueType.LONG);
+        age = await tx.concepts.putAttributeType("age", Concept.ValueType.LONG);
         await person.asRemote(tx).setAbstract();
         await person.asRemote(tx).setOwns(email, [Annotation.KEY]);
         man = await tx.concepts.getEntityType("man");
@@ -219,7 +219,7 @@ async function run() {
         await customer.asRemote(tx).setOwns(workEmail, email);
         const ownedAttributes = await customer.asRemote(tx).getOwns().collect();
         const ownedKeys = await customer.asRemote(tx).getOwns([Annotation.KEY]).collect();
-        const ownedDateTimes = await customer.asRemote(tx).getOwns(AttributeType.ValueType.DATETIME, []).collect();
+        const ownedDateTimes = await customer.asRemote(tx).getOwns(Concept.ValueType.DATETIME, []).collect();
         await tx.commit();
         await tx.close();
         assert(ownedAttributes.length === 2);
@@ -257,11 +257,11 @@ async function run() {
     let password, shoeSize, volume, isAlive, startDate;
     try {
         tx = await session.transaction(TransactionType.WRITE);
-        password = await tx.concepts.putAttributeType("password", AttributeType.ValueType.STRING);
-        shoeSize = await tx.concepts.putAttributeType("shoe-size", AttributeType.ValueType.LONG);
-        volume = await tx.concepts.putAttributeType("volume", AttributeType.ValueType.DOUBLE);
-        isAlive = await tx.concepts.putAttributeType("is-alive", AttributeType.ValueType.BOOLEAN);
-        startDate = await tx.concepts.putAttributeType("start-date", AttributeType.ValueType.DATETIME);
+        password = await tx.concepts.putAttributeType("password", Concept.ValueType.STRING);
+        shoeSize = await tx.concepts.putAttributeType("shoe-size", Concept.ValueType.LONG);
+        volume = await tx.concepts.putAttributeType("volume", Concept.ValueType.DOUBLE);
+        isAlive = await tx.concepts.putAttributeType("is-alive", Concept.ValueType.BOOLEAN);
+        startDate = await tx.concepts.putAttributeType("start-date", Concept.ValueType.DATETIME);
         await tx.commit();
         await tx.close();
         console.log(`put all 5 attribute value types - SUCCESS - password is a ${password.valueType}, shoe-size is a ${shoeSize.valueType}, `


### PR DESCRIPTION
## What is the goal of this PR?

Introduce the 'Value' type, which is returned as the result of an expression's computation. This change follows from https://github.com/vaticle/typeql/pull/260, which outlines the capabilities of the new expression syntax.

Values (representing any of Long, Double, Boolean, String, or DateTime) are returned as part of `ConceptMap` answers and are subtypes of `Concept` for the time being. Their main API is made of the `.getValue()` method and `.getValueType()` method, along with all the standard safe downcasting methods to convert a `Concept` into a `Value`, using `Concept.isValue()` and `Concept.asValue()`.

We also move the import location of `ValueType` from being nested in `AttributeType` to `Concept`.

## What are the changes implemented in this PR?

* Introduces the `Value` concept and the required `ValueImpl` that implements it
* Refactor `ValueType` to no longer live within `AttributeType` - now it exists in `Concept.ValueType`
* Updates the test framework for tests involving values, including the new `ExpressionTest` behaviour scenarios, which we also add to CI